### PR TITLE
Fix undefined manifest fetch

### DIFF
--- a/apps/frontend/react-router.config.ts
+++ b/apps/frontend/react-router.config.ts
@@ -3,6 +3,10 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "src",
   ssr: true,
+  routeDiscovery: {
+    mode: "lazy",
+    manifestPath: "/__manifest",
+  },
   async prerender() {
     return ["/", "/about"];
   },


### PR DESCRIPTION
## Summary
- ensure react-router manifest path is configured

## Testing
- `yarn workspace @alliance/frontend lint` *(fails: Unknown property 'tremor-id' etc.)*
- `yarn workspace @alliance/frontend tsc` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6841d9b6416483259ad1b1c438cc9c9e