### PR TITLE
Clear notifications for deleted forum replies

### DIFF
--- a/server/src/forum/forum.service.ts
+++ b/server/src/forum/forum.service.ts
@@ -345,6 +345,19 @@ export class ForumService {
       throw new NotFoundException('You can only delete your own replies');
     }
 
+    // Clear notifications that point to this deleted reply
+    // For forum comments, the parentObjectId is the post ID when parentObjectType is 'post'
+    if (reply.parentObjectType === CommentParentObject.Post) {
+      const replyNotificationUrl = replyUrl(reply.parentObjectId, reply.id);
+      await this.notifRepository.update(
+        {
+          webAppLocation: replyNotificationUrl,
+          category: NotificationType.ForumReply,
+        },
+        { cleared: true },
+      );
+    }
+
     await this.commentRepository.update(id, { deleted: true });
   }
 


### PR DESCRIPTION
When a forum reply/comment is deleted, clear any notifications that point to it to prevent users from seeing dead links in their notification panel.

🤖 Generated with [Claude Code](https://claude.ai/code)