### PR TITLE
Sync action activity likes between detail and list views

### DIFF
--- a/apps/frontend/src/components/ActionActivityDetail.tsx
+++ b/apps/frontend/src/components/ActionActivityDetail.tsx
@@ -1,10 +1,13 @@
 import { useActionLoaderData } from "../pages/app/ActionPage";
 import chevronLeft from "../assets/icons8-expand-arrow-96.png";
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams, useOutletContext } from "react-router";
 import { formatTime } from "../lib/utils";
-import { ActionActivityDto, actionsGetActivity } from "@alliance/shared/client";
+import { ActionActivityDto } from "@alliance/shared/client";
 import { useEffect, useState } from "react";
 import Comments from "./Comments";
+import heart from "../assets/icons8-heart-90.png";
+import { useAuth } from "../lib/AuthContext";
+import { TaskPanelContext } from "./ActionTaskPanel";
 
 export function formatActivityMessage(activity: ActionActivityDto) {
   const userName = activity.user.displayName || "Someone";
@@ -45,28 +48,22 @@ export function ErrorBoundary(error: unknown) {
 const ActionActivityDetail = () => {
   const navigate = useNavigate();
   const action = useActionLoaderData();
-  const actionId = action.id;
   const params = useParams();
   const activityId = parseInt(params.activityId!);
-  const [activity, setActivity] = useState<ActionActivityDto | null>(null);
+  const { user } = useAuth();
+  const { activities, handleLikeActivity, setActivities } = useOutletContext<TaskPanelContext>();
+  
+  // Find the activity from the shared state
+  const activity = activities.find(a => a.id === activityId) || null;
 
-  useEffect(() => {
-    const fetchActivities = async () => {
-      try {
-        const response = await actionsGetActivity({
-          path: { id: activityId },
-        });
-        if (!response.data) {
-          throw new Error();
-        }
-        setActivity(response.data);
-      } catch (err) {
-        console.error("Error fetching activities:", err);
-      }
-    };
+  const handleLike = async () => {
+    if (!user || !activity) {
+      return;
+    }
+    await handleLikeActivity(activity.id);
+  };
 
-    fetchActivities();
-  }, [actionId, activityId]);
+  const isLiked = activity?.likes.some((like) => like.id === user?.id) || false;
 
   return (
     <div className="flex flex-col gap-y-3 flex-2 px-5 pl-10 pt-5">
@@ -108,17 +105,38 @@ const ActionActivityDetail = () => {
               className="w-full h-auto rounded-md object-cover"
             />
           ))}
-          <div className="flex flex-row items-center gap-x-2">
-            <p className="">{activity.likes.length} likes</p>
-            {activity.likes
-              .filter((like) => like.profilePicture !== null)
-              .map((like) => (
+          <div className="flex flex-row items-center justify-between">
+            <div className="flex flex-row items-center gap-x-2">
+              <button
+                onClick={handleLike}
+                className="flex items-center gap-x-2 hover:bg-gray-100 rounded-md px-3 py-1.5 transition-colors cursor-pointer"
+              >
                 <img
-                  key={like.id}
-                  src={like.profilePicture!}
-                  className="w-6 h-6 rounded-md object-cover"
+                  src={heart}
+                  alt="Like"
+                  className={`w-5 h-5 transition-opacity ${
+                    isLiked ? "opacity-80" : "opacity-30"
+                  } hover:opacity-50`}
                 />
-              ))}
+                <span className="text-sm font-medium">{activity.likes.length} {activity.likes.length === 1 ? 'like' : 'likes'}</span>
+              </button>
+              {activity.likes
+                .filter((like) => like.profilePicture !== null)
+                .slice(0, 5)
+                .map((like) => (
+                  <img
+                    key={like.id}
+                    src={like.profilePicture!}
+                    className="w-6 h-6 rounded-md object-cover"
+                    title={like.displayName}
+                  />
+                ))}
+              {activity.likes.length > 5 && (
+                <span className="text-sm text-gray-500">
+                  +{activity.likes.length - 5} more
+                </span>
+              )}
+            </div>
           </div>
           <Comments objectId={activity.id} type={"activity"} />
         </>

--- a/apps/frontend/src/components/ActionActivityList.tsx
+++ b/apps/frontend/src/components/ActionActivityList.tsx
@@ -1,13 +1,7 @@
-import { useEffect, useState } from "react";
-import {
-  ActionActivityDto,
-  actionsLikeActivity,
-  actionsUnlikeActivity,
-} from "@alliance/shared/client";
-import { actionsGetActionActivities } from "@alliance/shared/client";
+import { useState } from "react";
+import { ActionActivityDto } from "@alliance/shared/client";
 import { CardStyle } from "./system/Card";
 import Card from "./system/Card";
-import { useActionActivity } from "../lib/useActionActivityWebSocket";
 import { formatTime } from "../lib/utils";
 import { useNavigate } from "react-router";
 import { formatActivityMessage } from "./ActionActivityDetail";
@@ -16,48 +10,27 @@ import { useAuth } from "../lib/AuthContext";
 
 interface ActionActivityListProps {
   actionId: number;
+  activities: ActionActivityDto[];
+  loading: boolean;
+  onLikeActivity: (activityId: number) => Promise<void>;
+  setActivities: React.Dispatch<React.SetStateAction<ActionActivityDto[]>>;
 }
 
-const ActionActivityList = ({ actionId }: ActionActivityListProps) => {
-  const [initialActivities, setInitialActivities] = useState<
-    ActionActivityDto[]
-  >([]);
-  const [loading, setLoading] = useState(true);
+const ActionActivityList = ({ 
+  actionId, 
+  activities, 
+  loading, 
+  onLikeActivity,
+  setActivities 
+}: ActionActivityListProps) => {
   const [showAll, setShowAll] = useState(false);
-  const { activities: liveActivities } = useActionActivity(actionId);
   const { user } = useAuth();
 
-  useEffect(() => {
-    const fetchActivities = async () => {
-      try {
-        setLoading(true);
-        const response = await actionsGetActionActivities({
-          path: { id: actionId },
-        });
-        if (!response.data) {
-          throw new Error();
-        }
-        setInitialActivities(response.data);
-      } catch (err) {
-        console.error("Error fetching activities:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchActivities();
-  }, [actionId]);
-
-  // Combine initial activities with live activities, avoiding duplicates
-  const allActivities = [...liveActivities, ...initialActivities]
-    .filter(
-      (activity, index, self) =>
-        self.findIndex((a) => a.id === activity.id) === index
-    )
-    .sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    );
+  // Sort activities by creation date
+  const allActivities = [...activities].sort(
+    (a, b) =>
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
 
   const navigate = useNavigate();
 
@@ -79,39 +52,7 @@ const ActionActivityList = ({ actionId }: ActionActivityListProps) => {
     if (!user) {
       return;
     }
-    if (activity.likes.some((like) => like.id === user.id)) {
-      const response = await actionsUnlikeActivity({
-        path: { id: activity.id },
-      });
-      if (response.response.ok) {
-        setInitialActivities(
-          initialActivities.map((a) =>
-            a.id === activity.id
-              ? {
-                  ...a,
-                  likes: a.likes.filter((like) => like.id !== user.id),
-                }
-              : a
-          )
-        );
-      }
-    } else {
-      const response = await actionsLikeActivity({
-        path: { id: activity.id },
-      });
-      if (response.response.ok) {
-        setInitialActivities(
-          initialActivities.map((a) =>
-            a.id === activity.id
-              ? {
-                  ...a,
-                  likes: response.data?.likes || [],
-                }
-              : a
-          )
-        );
-      }
-    }
+    await onLikeActivity(activity.id);
   };
 
   if (!allActivities.length) {
@@ -169,11 +110,11 @@ const ActionActivityList = ({ actionId }: ActionActivityListProps) => {
                     <img
                       src={heart}
                       alt="Like"
-                      className={`w-4 h-4 ${
+                      className={`w-4 h-4 cursor-pointer transition-opacity ${
                         activity.likes.some((like) => like.id === user?.id)
-                          ? "opacity-60"
-                          : "opacity-20"
-                      }`}
+                          ? "opacity-80"
+                          : "opacity-30"
+                      } hover:opacity-50`}
                       onClick={(e) => {
                         e.stopPropagation();
                         handleLike(activity);

--- a/apps/frontend/src/components/ActionTaskPanel.tsx
+++ b/apps/frontend/src/components/ActionTaskPanel.tsx
@@ -1,4 +1,4 @@
-import { UserActionDto } from "@alliance/shared/client";
+import { UserActionDto, ActionActivityDto } from "@alliance/shared/client";
 import ActionTaskPanelFunding from "./ActionTaskPanelFunding";
 import { StripeWrapper } from "./StripeWrapper";
 import ActionTaskPanelCompleted from "./ActionTaskPanelCompleted";
@@ -30,6 +30,9 @@ export type TaskPanelContext = {
   handleCompleteAction: () => void;
   handleJoinAction: () => void;
   userRelation: UserActionDto["status"] | null;
+  activities: ActionActivityDto[];
+  handleLikeActivity: (activityId: number) => Promise<void>;
+  setActivities: React.Dispatch<React.SetStateAction<ActionActivityDto[]>>;
 };
 
 const ActionTaskPanel = () => {

--- a/apps/frontend/src/pages/app/ActionPage.tsx
+++ b/apps/frontend/src/pages/app/ActionPage.tsx
@@ -15,9 +15,14 @@ import {
   actionsMyStatus,
   actionsUserLocations,
   LatLonDto,
+  actionsGetActionActivities,
+  actionsLikeActivity,
+  actionsUnlikeActivity,
+  ActionActivityDto,
 } from "@alliance/shared/client";
 import { ActionDto, UserActionDto } from "@alliance/shared/client";
 import { useActionCount } from "../../lib/useActionWebSocket";
+import { useActionActivity } from "../../lib/useActionActivityWebSocket";
 import TwoColumnSplit from "../../components/system/TwoColumnSplit";
 import ActionEventsPanel from "../../components/ActionEventsPanel";
 import CompletedBar from "../../components/CompletedBar";
@@ -105,12 +110,52 @@ export default function ActionPage() {
   const [userRelation, setUserRelation] = useState<
     UserActionDto["status"] | null
   >(null);
+  const [activities, setActivities] = useState<ActionActivityDto[]>([]);
+  const [activitiesLoading, setActivitiesLoading] = useState(true);
 
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, user } = useAuth();
 
   const actionId = action?.id || 0;
   const liveUserCount = useActionCount(actionId);
   const { revalidate } = useAppLoaderData();
+  const { activities: liveActivities } = useActionActivity(actionId);
+
+  // Fetch initial activities
+  useEffect(() => {
+    const fetchActivities = async () => {
+      if (!actionId) return;
+      try {
+        setActivitiesLoading(true);
+        const response = await actionsGetActionActivities({
+          path: { id: actionId },
+        });
+        if (response.data) {
+          setActivities(response.data);
+        }
+      } catch (err) {
+        console.error("Error fetching activities:", err);
+      } finally {
+        setActivitiesLoading(false);
+      }
+    };
+
+    fetchActivities();
+  }, [actionId]);
+
+  // Update activities when new websocket activities arrive
+  useEffect(() => {
+    if (liveActivities.length > 0) {
+      setActivities(prev => {
+        const newActivities = [...liveActivities, ...prev];
+        // Remove duplicates based on id
+        const uniqueActivities = newActivities.filter(
+          (activity, index, self) =>
+            self.findIndex((a) => a.id === activity.id) === index
+        );
+        return uniqueActivities;
+      });
+    }
+  }, [liveActivities]);
 
   useEffect(() => {
     if (isAuthenticated && id) {
@@ -156,6 +201,49 @@ export default function ActionPage() {
     }
   }, [id, revalidate]);
 
+  const handleLikeActivity = useCallback(async (activityId: number) => {
+    if (!user) return;
+    
+    const activity = activities.find(a => a.id === activityId);
+    if (!activity) return;
+
+    const isLiked = activity.likes.some((like) => like.id === user.id);
+    
+    if (isLiked) {
+      const response = await actionsUnlikeActivity({
+        path: { id: activityId },
+      });
+      if (response.response.ok) {
+        setActivities(prev => 
+          prev.map(a =>
+            a.id === activityId
+              ? {
+                  ...a,
+                  likes: a.likes.filter((like) => like.id !== user.id),
+                }
+              : a
+          )
+        );
+      }
+    } else {
+      const response = await actionsLikeActivity({
+        path: { id: activityId },
+      });
+      if (response.response.ok && response.data) {
+        setActivities(prev =>
+          prev.map(a =>
+            a.id === activityId
+              ? {
+                  ...a,
+                  likes: response.data.likes || [],
+                }
+              : a
+          )
+        );
+      }
+    }
+  }, [user, activities]);
+
   return (
     <TwoColumnSplit
       left={
@@ -165,6 +253,9 @@ export default function ActionPage() {
               userRelation,
               handleCompleteAction,
               handleJoinAction: onJoinAction,
+              activities,
+              handleLikeActivity,
+              setActivities,
             } satisfies TaskPanelContext
           }
         />
@@ -233,7 +324,15 @@ export default function ActionPage() {
               <ActionEventsPanel events={action.events} />
             </Card>
           )}
-          {action && <ActionActivityList actionId={action.id} />}
+          {action && (
+            <ActionActivityList 
+              actionId={action.id} 
+              activities={activities}
+              loading={activitiesLoading}
+              onLikeActivity={handleLikeActivity}
+              setActivities={setActivities}
+            />
+          )}
         </div>
       }
       bg="bg-white"


### PR DESCRIPTION
## Summary
- Centralized activity like state management in ActionPage component for consistent behavior
- Added interactive heart button to ActionActivityDetail page for liking/unliking activities
- Synchronized like states between sidebar list and detail view for seamless user experience

## Changes
- **State Management**: Moved activities state and like handling logic to parent ActionPage component
- **Context Extension**: Updated TaskPanelContext to pass activities and handlers through outlet context
- **Component Updates**: 
  - ActionActivityList now receives state as props instead of managing its own
  - ActionActivityDetail uses shared state and includes clickable heart button
- **WebSocket Integration**: Parent component handles both initial data and live updates without duplicates
- **UI Improvements**: Consistent hover effects (50% opacity) and visual feedback across both views

## Test Plan
- [ ] Navigate to an action page with activities
- [ ] Click heart icon in sidebar list - verify it toggles like state
- [ ] Click on activity to open detail view
- [ ] Verify like state matches between list and detail
- [ ] Click heart button on detail page - verify it toggles
- [ ] Navigate back to action page - verify sidebar reflects updated like state
- [ ] Test with multiple activities and WebSocket updates

🤖 Generated with [Claude Code](https://claude.ai/code)