### PR TITLE
[ALL-862] Display users with profile photos first in feed

### DIFF
--- a/apps/frontend/src/components/GlobalFeed.tsx
+++ b/apps/frontend/src/components/GlobalFeed.tsx
@@ -28,7 +28,9 @@ const ProfilePicRow = ({
   maxDisplay = 20,
   showExtraCount = false,
 }: ProfilePicRowProps) => {
-  const displayUsers = users.slice(0, maxDisplay);
+  const displayUsers = [...users]
+    .sort((a, b) => (b.profilePicture ? 1 : 0) - (a.profilePicture ? 1 : 0))
+    .slice(0, maxDisplay);
   const extraCount = users.length > maxDisplay ? users.length - maxDisplay : 0;
 
   return (

--- a/apps/frontend/src/components/UserProfilePicRow.tsx
+++ b/apps/frontend/src/components/UserProfilePicRow.tsx
@@ -8,9 +8,11 @@ import { useState } from "react";
 import { href } from "react-router";
 
 const UserProfilePicRow = ({ users }: { users: ProfileDto[] }) => {
-  const unique = users.filter(function (item, pos, self) {
-    return self.findIndex((t) => t.id === item.id) === pos;
-  });
+  const unique = users
+    .filter(function (item, pos, self) {
+      return self.findIndex((t) => t.id === item.id) === pos;
+    })
+    .sort((a, b) => (b.profilePicture ? 1 : 0) - (a.profilePicture ? 1 : 0));
 
   const [expanded, setExpanded] = useState(false);
 


### PR DESCRIPTION
**Before:**
<img width="338" height="330" alt="Screenshot 2026-04-14 at 17 06 59" src="https://github.com/user-attachments/assets/17328fdf-fbd9-4ead-aa8e-b8b39da6d67d" />

 ---

**After:**
<img width="340" height="338" alt="Screenshot 2026-04-14 at 17 07 15" src="https://github.com/user-attachments/assets/e4ebbc3e-44d8-4ea7-8a14-dd701621ea5b" />

<img width="649" height="225" alt="Screenshot 2026-04-14 at 17 17 07" src="https://github.com/user-attachments/assets/efce245e-b42a-4fb3-9fe2-cd75724c9348" />

<img width="683" height="112" alt="Screenshot 2026-04-14 at 17 23 24" src="https://github.com/user-attachments/assets/5e3b57fe-b188-459a-a250-c804122ce8b8" />

