### PR TITLE
[ALL-667] Group all members filters in same place

### DIFF
--- a/apps/admin/src/pages/GroupDetailPage.tsx
+++ b/apps/admin/src/pages/GroupDetailPage.tsx
@@ -866,6 +866,7 @@ const CommunityDetailPage: React.FC = () => {
           memberContactInfo={memberContactInfo ?? undefined}
           completedAllCurrentActions={completedAllCurrentActions}
           showInfoTooltip
+          showContractFilter
         />
       </div>
     </div>

--- a/apps/admin/src/pages/UsersList.tsx
+++ b/apps/admin/src/pages/UsersList.tsx
@@ -21,7 +21,6 @@ import {
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "@alliance/shared/styles/util";
 import UserCard from "../components/UserCard";
-import DropdownSelect from "@alliance/sharedweb/ui/DropdownSelect";
 import { useOutsideClick } from "@alliance/sharedweb/lib/useOutsideClick";
 import { href, Link, useSearchParams } from "react-router";
 import { LayoutGrid, List, Shuffle } from "lucide-react";
@@ -31,13 +30,6 @@ import { useMaxActionsPerWeek } from "@alliance/sharedweb/ui/UserProgressPills";
 import { shuffleWithSeed } from "@alliance/shared/forms/randomutils";
 
 type ViewMode = "cards" | "rows";
-
-enum UserFilterMode {
-  ALL = "All",
-  SIGNED = "Signed",
-  SUSPENDED = "Suspended",
-  NOT_SIGNED = "Not signed",
-}
 
 const UsersList: React.FC = () => {
   const [users, setUsers] = useState<UserDto[]>([]);
@@ -62,9 +54,6 @@ const UsersList: React.FC = () => {
     userActionRelations,
   });
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
-  const [filterMode, setFilterMode] = useState<UserFilterMode>(
-    UserFilterMode.SIGNED
-  );
   const [isTagFilterOpen, setIsTagFilterOpen] = useState(false);
   const tagDropdownRef = useOutsideClick(() => setIsTagFilterOpen(false));
   const [pendingTagOps, setPendingTagOps] = useState<Set<string>>(
@@ -74,7 +63,7 @@ const UsersList: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState("");
 
   const [params, setParams] = useSearchParams();
-  const viewMode = (params.get("viewMode") as ViewMode | undefined) ?? "cards";
+  const viewMode = (params.get("viewMode") as ViewMode | undefined) ?? "rows";
 
   const [shuffledIds, setShuffledIds] = useState<number[] | null>(null);
 
@@ -178,31 +167,8 @@ const UsersList: React.FC = () => {
     });
   }, [filteredByTags, searchQuery]);
 
-  const modeToUsers = useMemo(() => {
-    return Object.values(UserFilterMode).reduce((acc, mode) => {
-      acc[mode] = filteredBySearch.filter((user) => {
-        if (mode === UserFilterMode.ALL) {
-          return true;
-        }
-        const lastEvent = user.contractEvents?.sort(
-          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-        )[0];
-        if (mode === UserFilterMode.NOT_SIGNED) {
-          return !user.contractEvents?.length;
-        }
-        if (mode === UserFilterMode.SIGNED) {
-          return lastEvent?.type === "signed";
-        }
-        if (mode === UserFilterMode.SUSPENDED) {
-          return lastEvent?.type === "suspended";
-        }
-      });
-      return acc;
-    }, {} as Record<UserFilterMode, UserDto[]>);
-  }, [filteredBySearch]);
-
   const handleShuffle = useCallback(() => {
-    const current = modeToUsers[filterMode] ?? [];
+    const current = filteredBySearch;
 
     const seed = Math.random().toString(36).substring(2, 15);
     setShuffledIds(
@@ -211,7 +177,7 @@ const UsersList: React.FC = () => {
         seed
       )
     );
-  }, [filterMode, modeToUsers]);
+  }, [filteredBySearch]);
 
   const selectedTagNames = useMemo(() => {
     if (!selectedTagIds.length) return [] as string[];
@@ -221,7 +187,7 @@ const UsersList: React.FC = () => {
 
   useEffect(() => {
     setShuffledIds(null);
-  }, [filterMode, selectedTagIds, searchQuery]);
+  }, [selectedTagIds, searchQuery]);
 
   const groupFilterLabel = useMemo(() => {
     if (!selectedTagIds.length) {
@@ -249,16 +215,13 @@ const UsersList: React.FC = () => {
   const resetAllFilters = () => {
     setSearchQuery("");
     setSelectedTagIds([]);
-    setFilterMode(UserFilterMode.ALL);
   };
 
   const hasActiveFilters =
-    searchQuery.trim() !== "" ||
-    selectedTagIds.length > 0 ||
-    filterMode !== UserFilterMode.ALL;
+    searchQuery.trim() !== "" || selectedTagIds.length > 0;
 
   const usersAsProfiles = useMemo((): ProfileDto[] => {
-    return (modeToUsers[filterMode] ?? []).map((user) => {
+    return filteredBySearch.map((user) => {
       const lastEvent = user.contractEvents?.sort(
         (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
       )[0];
@@ -275,20 +238,38 @@ const UsersList: React.FC = () => {
         anonymous: user.anonymous,
       };
     });
-  }, [modeToUsers, filterMode]);
+  }, [filteredBySearch]);
+
+  const { completedAllCurrentActions } = useMemo<{
+    completedAllCurrentActions: Record<number, boolean>;
+    nCompleted: number;
+    nTotal: number;
+  }>(() => {
+    if (!userActionRelations) {
+      return {
+        completedAllCurrentActions: {} as Record<number, boolean>,
+        nCompleted: 0,
+        nTotal: 0,
+      };
+    }
+
+    return calculateCompletionData({
+      filteredActionIds: activeActions.map((a) => a.id),
+      userActionRelations,
+    });
+  }, [activeActions, userActionRelations]);
 
   const displayedUsers = useMemo(() => {
-    const list = modeToUsers[filterMode] ?? [];
     if (
       shuffledIds != null &&
-      shuffledIds.length === list.length &&
-      list.every((u) => shuffledIds!.includes(u.id))
+      shuffledIds.length === filteredBySearch.length &&
+      filteredBySearch.every((u) => shuffledIds!.includes(u.id))
     ) {
-      const byId = Object.fromEntries(list.map((u) => [u.id, u]));
+      const byId = Object.fromEntries(filteredBySearch.map((u) => [u.id, u]));
       return shuffledIds.map((id) => byId[id]).filter(Boolean);
     }
-    return list;
-  }, [filterMode, modeToUsers, shuffledIds]);
+    return filteredBySearch;
+  }, [filteredBySearch, shuffledIds]);
 
   const displayedProfiles = useMemo((): ProfileDto[] => {
     const list = usersAsProfiles;
@@ -320,24 +301,7 @@ const UsersList: React.FC = () => {
     });
   }, []);
 
-  const { completedAllCurrentActions } = useMemo<{
-    completedAllCurrentActions: Record<number, boolean>;
-    nCompleted: number;
-    nTotal: number;
-  }>(() => {
-    if (!userActionRelations) {
-      return {
-        completedAllCurrentActions: {} as Record<number, boolean>,
-        nCompleted: 0,
-        nTotal: 0,
-      };
-    }
 
-    return calculateCompletionData({
-      filteredActionIds: activeActions.map((a) => a.id),
-      userActionRelations,
-    });
-  }, [activeActions, userActionRelations]);
 
   const updateTagInState = useCallback((updatedTag: TagDto) => {
     setTags((prev) => {
@@ -402,14 +366,6 @@ const UsersList: React.FC = () => {
           className="text-sm border border-gray-2 text-black bg-white px-3 rounded-sm py-2 w-64 focus:outline-none focus:border-black"
         />
         <div className="flex flex-row gap-3 items-center">
-          <DropdownSelect
-            options={UserFilterMode}
-            secondaryLabel={([, mode]) =>
-              (modeToUsers[mode]?.length ?? 0).toString()
-            }
-            value={filterMode}
-            onChange={([, mode]) => setFilterMode(mode)}
-          />
           <div className="relative" ref={tagDropdownRef}>
             <button
               type="button"
@@ -494,17 +450,6 @@ const UsersList: React.FC = () => {
           </button>
           <button
             type="button"
-            onClick={() => setParams({ viewMode: "cards" })}
-            className={cn(
-              "p-2 rounded",
-              viewMode === "cards" ? "bg-zinc-200" : "hover:bg-zinc-100"
-            )}
-            title="Card view"
-          >
-            <LayoutGrid size={18} className="text-zinc-600" />
-          </button>
-          <button
-            type="button"
             onClick={() => setParams({ viewMode: "rows" })}
             className={cn(
               "p-2 rounded",
@@ -513,6 +458,17 @@ const UsersList: React.FC = () => {
             title="Table view"
           >
             <List size={18} className="text-zinc-600" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setParams({ viewMode: "cards" })}
+            className={cn(
+              "p-2 rounded",
+              viewMode === "cards" ? "bg-zinc-200" : "hover:bg-zinc-100"
+            )}
+            title="Card view"
+          >
+            <LayoutGrid size={18} className="text-zinc-600" />
           </button>
         </div>
       </div>
@@ -553,6 +509,7 @@ const UsersList: React.FC = () => {
             maxActionsPerWeek={maxActionsPerWeek}
             completedAllCurrentActions={completedAllCurrentActions}
             showInfoTooltip
+            showContractFilter
           />
         </div>
       )}

--- a/apps/admin/src/pages/UsersList.tsx
+++ b/apps/admin/src/pages/UsersList.tsx
@@ -63,7 +63,7 @@ const UsersList: React.FC = () => {
   });
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
   const [filterMode, setFilterMode] = useState<UserFilterMode>(
-    UserFilterMode.ALL
+    UserFilterMode.SIGNED
   );
   const [isTagFilterOpen, setIsTagFilterOpen] = useState(false);
   const tagDropdownRef = useOutsideClick(() => setIsTagFilterOpen(false));

--- a/server/src/community/community.service.ts
+++ b/server/src/community/community.service.ts
@@ -106,7 +106,10 @@ export class CommunityService {
 
   async findAllCommunities(): Promise<Community[]> {
     const communities = await this.communityRepository.find({
-      relations: COMMUNITY_DEFAULT_RELATIONS,
+      relations: {
+        ...COMMUNITY_DEFAULT_RELATIONS,
+        users: { contractEvents: true } as const,
+      },
     });
     return communities.sort((a, b) => a.name.localeCompare(b.name));
   }

--- a/sharedweb/ui/CommunityMembersTable.tsx
+++ b/sharedweb/ui/CommunityMembersTable.tsx
@@ -13,7 +13,7 @@ import CommunityMemberTableRow from "./CommunityMemberTableRow";
 import DropdownSelect from "./DropdownSelect";
 
 export enum CommunityMembersFilterMode {
-  All = "All members",
+  All = "Any status",
   Completed = "Completed",
   NotYetCompleted = "Not yet completed",
 }

--- a/sharedweb/ui/CommunityMembersTable.tsx
+++ b/sharedweb/ui/CommunityMembersTable.tsx
@@ -12,10 +12,17 @@ import {
 import CommunityMemberTableRow from "./CommunityMemberTableRow";
 import DropdownSelect from "./DropdownSelect";
 
-export enum CommunityMembersFilterMode {
+export enum CompletionFilterMode {
   All = "Any status",
   Completed = "Completed",
   NotYetCompleted = "Not yet completed",
+}
+
+export enum ContractFilterMode {
+  ALL = "All",
+  SIGNED = "Signed",
+  SUSPENDED = "Suspended",
+  NOT_SIGNED = "Not signed",
 }
 
 type CommunityMembersTableProps = {
@@ -30,6 +37,7 @@ type CommunityMembersTableProps = {
   completedAllCurrentActions?: Record<number, boolean>;
   maxActionsPerWeek: Record<number, number> | null;
   showInfoTooltip?: boolean;
+  showContractFilter?: boolean;
 };
 
 const CommunityMembersTable = ({
@@ -44,9 +52,13 @@ const CommunityMembersTable = ({
   completedAllCurrentActions = {},
   maxActionsPerWeek,
   showInfoTooltip = false,
+  showContractFilter = false,
 }: CommunityMembersTableProps) => {
-  const [filterMode, setFilterMode] = useState<CommunityMembersFilterMode>(
-    CommunityMembersFilterMode.All,
+  const [completionFilter, setCompletionFilter] = useState<CompletionFilterMode>(
+    CompletionFilterMode.All,
+  );
+  const [contractFilter, setContractFilter] = useState<ContractFilterMode>(
+    showContractFilter ? ContractFilterMode.SIGNED : ContractFilterMode.ALL,
   );
   const visibleActions = useMemo(() => {
     return actions.filter((action) => action.status !== "planned");
@@ -60,20 +72,53 @@ const CommunityMembersTable = ({
     [userActionRelations, actions],
   );
 
-  const membersByFilterMode = useMemo(() => {
+  const filteredByContract = useMemo(() => {
+    if (contractFilter === ContractFilterMode.ALL) {
+      return members;
+    }
+    return members.filter((user) => {
+      if (contractFilter === ContractFilterMode.NOT_SIGNED) {
+        return !user.lastContractEvent;
+      }
+      if (contractFilter === ContractFilterMode.SIGNED) {
+        return user.lastContractEvent?.type === "signed";
+      }
+      if (contractFilter === ContractFilterMode.SUSPENDED) {
+        return user.lastContractEvent?.type === "suspended";
+      }
+      return true;
+    });
+  }, [contractFilter, members]);
+
+  const membersByContract = useMemo(() => {
     return {
-      [CommunityMembersFilterMode.All]: members,
-      [CommunityMembersFilterMode.NotYetCompleted]: members.filter(
+      [ContractFilterMode.ALL]: members,
+      [ContractFilterMode.SIGNED]: members.filter(
+        (user) => user.lastContractEvent?.type === "signed",
+      ),
+      [ContractFilterMode.SUSPENDED]: members.filter(
+        (user) => user.lastContractEvent?.type === "suspended",
+      ),
+      [ContractFilterMode.NOT_SIGNED]: members.filter(
+        (user) => !user.lastContractEvent,
+      ),
+    };
+  }, [members]);
+
+  const membersByCompletion = useMemo(() => {
+    return {
+      [CompletionFilterMode.All]: filteredByContract,
+      [CompletionFilterMode.NotYetCompleted]: filteredByContract.filter(
         (user) => !completedAllCurrentActions[user.id],
       ),
-      [CommunityMembersFilterMode.Completed]: members.filter(
+      [CompletionFilterMode.Completed]: filteredByContract.filter(
         (user) => completedAllCurrentActions[user.id],
       ),
     };
-  }, [completedAllCurrentActions, members]);
+  }, [completedAllCurrentActions, filteredByContract]);
 
   const filteredSortedMembers = useMemo(() => {
-    const filtered = membersByFilterMode[filterMode] ?? [];
+    const filtered = membersByCompletion[completionFilter] ?? [];
     if (!amLeader) return filtered;
     return sortMembersByNextTaskDue(
       filtered,
@@ -82,11 +127,22 @@ const CommunityMembersTable = ({
     );
   }, [
     amLeader,
-    filterMode,
+    completionFilter,
     memberContactInfo,
-    membersByFilterMode,
+    membersByCompletion,
     deadlineTimestampByUserId,
   ]);
+
+  const hasActiveFilters =
+    completionFilter !== CompletionFilterMode.All ||
+    (showContractFilter && contractFilter !== ContractFilterMode.SIGNED);
+
+  const resetFilters = () => {
+    setCompletionFilter(CompletionFilterMode.All);
+    setContractFilter(
+      showContractFilter ? ContractFilterMode.SIGNED : ContractFilterMode.ALL,
+    );
+  };
 
   return (
     <div className="flex flex-col py-4 mt-4">
@@ -167,14 +223,35 @@ const CommunityMembersTable = ({
                   <p className="text-zinc-500 text-sm">
                     Sort by completion of current actions
                   </p>
-                  <DropdownSelect
-                    options={CommunityMembersFilterMode}
-                    secondaryLabel={([, mode]) =>
-                      membersByFilterMode[mode].length.toString()
-                    }
-                    value={filterMode}
-                    onChange={([, mode]) => setFilterMode(mode)}
-                  />
+                  <div className="flex flex-row gap-3 items-center">
+                    {showContractFilter && (
+                      <DropdownSelect
+                        options={ContractFilterMode}
+                        secondaryLabel={([, mode]) =>
+                          membersByContract[mode].length.toString()
+                        }
+                        value={contractFilter}
+                        onChange={([, mode]) => setContractFilter(mode)}
+                      />
+                    )}
+                    <DropdownSelect
+                      options={CompletionFilterMode}
+                      secondaryLabel={([, mode]) =>
+                        membersByCompletion[mode].length.toString()
+                      }
+                      value={completionFilter}
+                      onChange={([, mode]) => setCompletionFilter(mode)}
+                    />
+                    {hasActiveFilters && (
+                      <button
+                        type="button"
+                        onClick={resetFilters}
+                        className="text-sm text-zinc-500 hover:text-zinc-700 hover:underline"
+                      >
+                        Reset filters
+                      </button>
+                    )}
+                  </div>
                 </div>
               </td>
             </tr>

--- a/sharedweb/ui/CommunityMembersTable.tsx
+++ b/sharedweb/ui/CommunityMembersTable.tsx
@@ -220,9 +220,6 @@ const CommunityMembersTable = ({
               <td colSpan={amLeader ? 4 : 2} className="px-5 md:px-0 pb-6 pt-6">
                 <div className="flex flex-col gap-y-2">
                   <p className="text-xl md:text-2xl font-semibold">Members</p>
-                  <p className="text-zinc-500 text-sm">
-                    Sort by completion of current actions
-                  </p>
                   <div className="flex flex-row gap-3 items-center">
                     {showContractFilter && (
                       <DropdownSelect


### PR DESCRIPTION
- Put "By task completion" and "By contract status" filters side-by-side above the table (instead of having "By contract status" be at the top next to the search bar)
- Default to "Contract: Signed" filter
- Default to list view in admin `/members`
- Adds "By contract status" filter to admin `/group/{id}` view, which uses the same `CommunityMembersTable` component as `/members`
 
---

**Before**
<img width="1435" height="570" alt="Screenshot 2026-04-16 at 17 08 03" src="https://github.com/user-attachments/assets/eeaadb98-f89e-43d7-91ef-e6a85eca8765" />

---

**After** 
<img width="1446" height="540" alt="Screenshot 2026-04-16 at 17 08 18" src="https://github.com/user-attachments/assets/a07bba81-729e-4d7f-8ba2-43b78f494d5a" />
