### PR TITLE
[ALL-979] Add num users dismissed to action dashboard for optional actions

### DIFF
--- a/apps/admin/src/pages/ActionDashboard.tsx
+++ b/apps/admin/src/pages/ActionDashboard.tsx
@@ -1207,6 +1207,27 @@ const ActionDashboard: React.FC = () => {
                   <div className="grid grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4">
                     <Card style={CardStyle.White} className="!p-4">
                       <div className="flex items-center gap-3">
+                        <div className="p-2 bg-purple-100 rounded-lg">
+                          <TrendingUp className="h-5 w-5 text-purple-600" />
+                        </div>
+                        <div>
+                          <p className="text-2xl font-bold">
+                            {action.usersJoined > 0
+                              ? Math.round(
+                                  (action.usersCompleted / action.usersJoined) *
+                                    100
+                                )
+                              : 0}
+                            %
+                          </p>
+                          <p className="text-xs text-gray-500">
+                            Completion Rate
+                          </p>
+                        </div>
+                      </div>
+                    </Card>
+                    <Card style={CardStyle.White} className="!p-4">
+                      <div className="flex items-center gap-3">
                         <div className="p-2 bg-blue-100 rounded-lg">
                           <Users className="h-5 w-5 text-blue-600" />
                         </div>
@@ -1245,27 +1266,6 @@ const ActionDashboard: React.FC = () => {
                             {actionStats?.usersWithdrawn ?? 0}
                           </p>
                           <p className="text-xs text-gray-500">Withdrawn</p>
-                        </div>
-                      </div>
-                    </Card>
-                    <Card style={CardStyle.White} className="!p-4">
-                      <div className="flex items-center gap-3">
-                        <div className="p-2 bg-purple-100 rounded-lg">
-                          <TrendingUp className="h-5 w-5 text-purple-600" />
-                        </div>
-                        <div>
-                          <p className="text-2xl font-bold">
-                            {action.usersJoined > 0
-                              ? Math.round(
-                                  (action.usersCompleted / action.usersJoined) *
-                                    100
-                                )
-                              : 0}
-                            %
-                          </p>
-                          <p className="text-xs text-gray-500">
-                            Completion Rate
-                          </p>
                         </div>
                       </div>
                     </Card>

--- a/apps/admin/src/pages/ActionDashboard.tsx
+++ b/apps/admin/src/pages/ActionDashboard.tsx
@@ -47,13 +47,13 @@ import {
   CheckIcon,
   ChevronDown,
   ChevronUp,
+  EyeOff,
   ListChecks,
   Users,
   UserCheck,
   UserMinus,
   UserX,
   TrendingUp,
-  InfoIcon,
 } from "lucide-react";
 import ActionCompletionCurveChart from "../components/ActionCompletionCurveChart";
 import { useNavigate, useParams, useSearchParams } from "react-router";
@@ -1298,17 +1298,17 @@ const ActionDashboard: React.FC = () => {
                       </Card>
                     )}
                     {action.optional && (
-                      <Card
-                        style={CardStyle.White}
-                        className="!p-4 items-center flex-row"
-                      >
+                      <Card style={CardStyle.White} className="!p-4">
                         <div className="flex items-center gap-3">
-                          <div className="p-2 bg-blue-100 rounded-lg">
-                            <InfoIcon className="h-5 w-5 text-blue-600" />
+                          <div className="p-2 bg-gray-100 rounded-lg">
+                            <EyeOff className="h-5 w-5 text-gray-600" />
                           </div>
-                          <p className="text font-medium text-gray-800">
-                            Optional action
-                          </p>
+                          <div>
+                            <p className="text-2xl font-bold">
+                              {actionStats?.usersDismissed ?? 0}
+                            </p>
+                            <p className="text-xs text-gray-500">Dismissed</p>
+                          </div>
                         </div>
                       </Card>
                     )}

--- a/server/migrations/1776470207644-add-users-dismissed-to-action-stats.ts
+++ b/server/migrations/1776470207644-add-users-dismissed-to-action-stats.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddUsersDismissedToActionStats1776470207644 implements MigrationInterface {
+    name = 'AddUsersDismissedToActionStats1776470207644'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "action_stats_record" ADD "usersDismissed" integer NOT NULL DEFAULT '0'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "action_stats_record" DROP COLUMN "usersDismissed"`);
+    }
+
+}

--- a/server/src/analytics/actionstats.entity.ts
+++ b/server/src/analytics/actionstats.entity.ts
@@ -35,6 +35,12 @@ export class ActionStatsRecord {
   })
   usersWithdrawn: number;
 
+  @Column({ default: 0 })
+  @ApiProperty({
+    description: 'Number of users who dismissed this optional action',
+  })
+  usersDismissed: number;
+
   @Column({ type: 'float' })
   @ApiProperty({
     description: 'Completion rate as a fraction (usersCompleted / usersJoined)',

--- a/server/src/analytics/analytics.service.ts
+++ b/server/src/analytics/analytics.service.ts
@@ -292,6 +292,7 @@ ORDER BY pp.total_session_duration_seconds DESC
 
     const actionIds = actions.map((action) => action.id);
     const withdrawalByActionId = new Map<number, number>();
+    const dismissalByActionId = new Map<number, number>();
     if (actionIds.length > 0) {
       const withdrawalCounts = await this.actionActivityRepository
         .createQueryBuilder('activity')
@@ -313,6 +314,25 @@ ORDER BY pp.total_session_duration_seconds DESC
           withdrawalByActionId.set(actionId, withdrawnCount);
         }
       }
+
+      const dismissalCounts = await this.actionActivityRepository
+        .createQueryBuilder('activity')
+        .select('activity.actionId', 'actionId')
+        .addSelect('COUNT(DISTINCT activity.userId)', 'dismissedCount')
+        .where('activity.actionId IN (:...actionIds)', { actionIds })
+        .andWhere('activity.type = :type', {
+          type: ActionActivityType.USER_DISMISSED,
+        })
+        .groupBy('activity.actionId')
+        .getRawMany<{ actionId: string; dismissedCount: string }>();
+
+      for (const row of dismissalCounts) {
+        const actionId = Number(row.actionId);
+        const dismissedCount = Number(row.dismissedCount);
+        if (!Number.isNaN(actionId) && !Number.isNaN(dismissedCount)) {
+          dismissalByActionId.set(actionId, dismissedCount);
+        }
+      }
     }
 
     for (const action of actions) {
@@ -331,6 +351,7 @@ ORDER BY pp.total_session_duration_seconds DESC
       const usersJoined = action.usersJoined;
       const usersCompleted = action.usersCompleted;
       const usersWithdrawn = withdrawalByActionId.get(action.id) ?? 0;
+      const usersDismissed = dismissalByActionId.get(action.id) ?? 0;
       const completionRate = usersJoined > 0 ? usersCompleted / usersJoined : 0;
 
       // Find member_action event dates
@@ -370,6 +391,7 @@ ORDER BY pp.total_session_duration_seconds DESC
         existingRecord.usersCompleted = usersCompleted;
         existingRecord.usersJoined = usersJoined;
         existingRecord.usersWithdrawn = usersWithdrawn;
+        existingRecord.usersDismissed = usersDismissed;
         existingRecord.completionRate = completionRate;
         existingRecord.lastCalculatedAt = now;
         existingRecord.actionCompletedAt = completedDate ?? undefined;
@@ -385,6 +407,7 @@ ORDER BY pp.total_session_duration_seconds DESC
           usersCompleted,
           usersJoined,
           usersWithdrawn,
+          usersDismissed,
           completionRate,
           lastCalculatedAt: now,
           actionCompletedAt: completedDate ?? undefined,

--- a/shared/client/types.gen.ts
+++ b/shared/client/types.gen.ts
@@ -2435,7 +2435,9 @@ export type TableDataDto = {
     /**
      * Table rows data - each row is an array of values corresponding to columns
      */
-    rows: Array<Array<unknown>>;
+    rows: Array<Array<string | number | boolean | {
+        [key: string]: unknown;
+    } | unknown>>;
     /**
      * Total number of records in the table (before pagination)
      */

--- a/shared/client/types.gen.ts
+++ b/shared/client/types.gen.ts
@@ -2435,9 +2435,7 @@ export type TableDataDto = {
     /**
      * Table rows data - each row is an array of values corresponding to columns
      */
-    rows: Array<Array<string | number | boolean | {
-        [key: string]: unknown;
-    } | unknown>>;
+    rows: Array<Array<unknown>>;
     /**
      * Total number of records in the table (before pagination)
      */
@@ -2748,6 +2746,10 @@ export type ActionStatsWithOnboardingDto = {
      * Number of users who withdrew from this action (declined or wont_complete)
      */
     usersWithdrawn: number;
+    /**
+     * Number of users who dismissed this optional action
+     */
+    usersDismissed: number;
     /**
      * Completion rate as a fraction (usersCompleted / usersJoined)
      */


### PR DESCRIPTION
* Add a count of the number of users that have dismissed an optional action
* Reorder statistics with completion rate first (Mark says it's most important) to avoid excessive visual clutter

Like withdrawal count, dismissal count is computed daily by a cronjob instead of being updated live.

<img width="1378" height="111" alt="Screenshot 2026-04-19 at 10 30 46" src="https://github.com/user-attachments/assets/08a8f259-cd7c-4dcd-ade6-f913aca1dd7d" />
