### PR TITLE
[ALL978] End action completion CDF at deadline

### DIFF
--- a/apps/admin/src/components/ActionCompletionCurveChart.tsx
+++ b/apps/admin/src/components/ActionCompletionCurveChart.tsx
@@ -15,10 +15,32 @@ type ActionCompletionCurveChartProps = {
   refreshKey?: number;
 };
 
-const LOCKED_MAX_DAY = 7;
-const LOCKED_MAX_HOUR = 168; // 7 days * 24 hours
-
 type GranularityMode = "daily" | "hourly";
+
+function computeMaxOffset(
+  curves: ActionCompletionCurveDto[],
+  isHourly: boolean,
+): number {
+  const msPerUnit = isHourly ? 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
+  let max = 0;
+  for (const curve of curves) {
+    if (isHourly) {
+      const lastOffset = curve.hourOffsets?.at(-1);
+      if (lastOffset !== undefined && lastOffset + 1 > max) max = lastOffset + 1;
+    } else {
+      const lastOffset = curve.dayOffsets?.at(-1);
+      if (lastOffset !== undefined && lastOffset > max) max = lastOffset;
+    }
+    // Also derive from dates if offsets are shorter than the full action duration
+    if (curve.memberActionStartDate && curve.memberActionEndDate) {
+      const start = new Date(curve.memberActionStartDate).getTime();
+      const end = new Date(curve.memberActionEndDate).getTime();
+      const duration = Math.ceil((end - start) / msPerUnit);
+      if (duration > max) max = duration;
+    }
+  }
+  return Math.max(1, max);
+}
 
 const ActionCompletionCurveChart: React.FC<ActionCompletionCurveChartProps> = ({
   title = "Completions throughout week",
@@ -137,7 +159,7 @@ const ActionCompletionCurveChart: React.FC<ActionCompletionCurveChartProps> = ({
       };
     }
 
-    const maxX = isHourly ? LOCKED_MAX_HOUR : LOCKED_MAX_DAY;
+    const maxX = computeMaxOffset(eligibleCurves, isHourly);
 
     const colorScale = chroma
       .scale(["#0ea5e9", "#6366f1", "#14b8a6"])

--- a/apps/admin/src/components/ActionCompletionCurveChart.tsx
+++ b/apps/admin/src/components/ActionCompletionCurveChart.tsx
@@ -56,6 +56,8 @@ const ActionCompletionCurveChart: React.FC<ActionCompletionCurveChartProps> = ({
     actionId !== undefined ? String(actionId) : "all"
   );
   const [granularity, setGranularity] = useState<GranularityMode>("hourly");
+  const [minDurationDays, setMinDurationDays] = useState<string>("");
+  const [maxDurationDays, setMaxDurationDays] = useState<string>("");
 
   useEffect(() => {
     if (actionId === undefined) return;
@@ -133,9 +135,53 @@ const ActionCompletionCurveChart: React.FC<ActionCompletionCurveChartProps> = ({
     }
   }, [actionId, completionCurveActionOptions, selectedActionId]);
 
+  // Default duration filter to ±3 days of the selected action's duration
+  const effectiveActionId = actionId !== undefined ? String(actionId) : selectedActionId;
+  useEffect(() => {
+    if (effectiveActionId === "all") {
+      setMinDurationDays("");
+      setMaxDurationDays("");
+      return;
+    }
+    const curve = actionCompletionCurves.find(
+      (c) => String(c.actionId) === effectiveActionId
+    );
+    if (!curve?.memberActionStartDate) return;
+    const msPerDay = 24 * 60 * 60 * 1000;
+    const start = new Date(curve.memberActionStartDate).getTime();
+    const end = curve.memberActionEndDate
+      ? new Date(curve.memberActionEndDate).getTime()
+      : Date.now();
+    const durationDays = Math.ceil((end - start) / msPerDay);
+    setMinDurationDays(String(Math.max(0, durationDays - 3)));
+    setMaxDurationDays(String(durationDays + 3));
+  }, [effectiveActionId, actionCompletionCurves]);
+
   const isHourly = granularity === "hourly";
 
   const actionCompletionCurveChartData = useMemo(() => {
+    const msPerDay = 24 * 60 * 60 * 1000;
+    const minDays = minDurationDays !== "" ? Number(minDurationDays) : null;
+    const maxDays = maxDurationDays !== "" ? Number(maxDurationDays) : null;
+
+    function curveDurationDays(curve: ActionCompletionCurveDto): number | null {
+      if (!curve.memberActionStartDate) return null;
+      const start = new Date(curve.memberActionStartDate).getTime();
+      const end = curve.memberActionEndDate
+        ? new Date(curve.memberActionEndDate).getTime()
+        : Date.now();
+      return Math.ceil((end - start) / msPerDay);
+    }
+
+    function passesDurationFilter(curve: ActionCompletionCurveDto): boolean {
+      if (minDays === null && maxDays === null) return true;
+      const days = curveDurationDays(curve);
+      if (days === null) return false;
+      if (minDays !== null && days < minDays) return false;
+      if (maxDays !== null && days > maxDays) return false;
+      return true;
+    }
+
     const eligibleCurves = actionCompletionCurves.filter((curve) => {
       if (isHourly) {
         const offsets = curve.hourOffsets;
@@ -151,7 +197,9 @@ const ActionCompletionCurveChart: React.FC<ActionCompletionCurveChartProps> = ({
       );
     });
 
-    if (eligibleCurves.length === 0) {
+    const durationFilteredCurves = eligibleCurves.filter(passesDurationFilter);
+
+    if (durationFilteredCurves.length === 0) {
       return {
         multiLineData: [] as MultiLineSeries[],
         maxX: 0,
@@ -159,17 +207,17 @@ const ActionCompletionCurveChart: React.FC<ActionCompletionCurveChartProps> = ({
       };
     }
 
-    const maxX = computeMaxOffset(eligibleCurves, isHourly);
+    const maxX = computeMaxOffset(durationFilteredCurves, isHourly);
 
     const colorScale = chroma
       .scale(["#0ea5e9", "#6366f1", "#14b8a6"])
       .mode("lch")
-      .domain([0, Math.max(1, eligibleCurves.length - 1)]);
+      .domain([0, Math.max(1, durationFilteredCurves.length - 1)]);
 
     const sumByBucket = new Array<number>(maxX + 1).fill(0);
     const countByBucket = new Array<number>(maxX + 1).fill(0);
 
-    const actionSeries: MultiLineSeries[] = eligibleCurves
+    const actionSeries: MultiLineSeries[] = durationFilteredCurves
       .slice()
       .sort((a, b) => a.actionName.localeCompare(b.actionName))
       .map((curve, index) => {
@@ -307,8 +355,8 @@ const ActionCompletionCurveChart: React.FC<ActionCompletionCurveChartProps> = ({
       filteredActionSeries.map((s) => s.key.replace("action-", ""))
     );
     const displayedCurves = selectedCurveIds.size > 0
-      ? eligibleCurves.filter((c) => selectedCurveIds.has(String(c.actionId)))
-      : eligibleCurves;
+      ? durationFilteredCurves.filter((c) => selectedCurveIds.has(String(c.actionId)))
+      : durationFilteredCurves;
     const displayedMaxX = computeMaxOffset(displayedCurves, isHourly);
 
     const displayedSeries = [...filteredActionSeries, averageSeries];
@@ -331,7 +379,7 @@ const ActionCompletionCurveChart: React.FC<ActionCompletionCurveChartProps> = ({
       maxX: displayedMaxX,
       yDomain: [0, paddedMax] as [number, number],
     };
-  }, [actionCompletionCurves, actionId, selectedActionId, isHourly]);
+  }, [actionCompletionCurves, actionId, selectedActionId, isHourly, minDurationDays, maxDurationDays]);
 
   const showDropdown = showSelector && actionId === undefined;
 
@@ -420,6 +468,40 @@ const ActionCompletionCurveChart: React.FC<ActionCompletionCurveChartProps> = ({
               </select>
             </div>
           )}
+          <div className="flex items-center gap-1.5">
+            <label className="text-xs font-semibold text-gray-600">
+              Duration (days)
+            </label>
+            <input
+              type="number"
+              min={0}
+              placeholder="min"
+              value={minDurationDays}
+              onChange={(e) => setMinDurationDays(e.target.value)}
+              className="w-14 rounded-md border border-gray-300 px-2 py-1 text-xs bg-white"
+            />
+            <span className="text-gray-400">–</span>
+            <input
+              type="number"
+              min={0}
+              placeholder="max"
+              value={maxDurationDays}
+              onChange={(e) => setMaxDurationDays(e.target.value)}
+              className="w-14 rounded-md border border-gray-300 px-2 py-1 text-xs bg-white"
+            />
+            {(minDurationDays !== "" || maxDurationDays !== "") && (
+              <button
+                type="button"
+                onClick={() => {
+                  setMinDurationDays("");
+                  setMaxDurationDays("");
+                }}
+                className="text-xs text-zinc-500 hover:text-zinc-700 hover:underline"
+              >
+                Clear filter
+              </button>
+            )}
+          </div>
         </div>
       }
       getHoverContent={(point, series) => {

--- a/apps/admin/src/components/ActionCompletionCurveChart.tsx
+++ b/apps/admin/src/components/ActionCompletionCurveChart.tsx
@@ -302,6 +302,15 @@ const ActionCompletionCurveChart: React.FC<ActionCompletionCurveChartProps> = ({
           (series) => series.key === `action-${selectedActionId}`
         );
 
+    // Compute display x-axis range from the selected curves only
+    const selectedCurveIds = new Set(
+      filteredActionSeries.map((s) => s.key.replace("action-", ""))
+    );
+    const displayedCurves = selectedCurveIds.size > 0
+      ? eligibleCurves.filter((c) => selectedCurveIds.has(String(c.actionId)))
+      : eligibleCurves;
+    const displayedMaxX = computeMaxOffset(displayedCurves, isHourly);
+
     const displayedSeries = [...filteredActionSeries, averageSeries];
     const allSeries = [...actionSeries, averageSeries];
 
@@ -319,7 +328,7 @@ const ActionCompletionCurveChart: React.FC<ActionCompletionCurveChartProps> = ({
 
     return {
       multiLineData: displayedSeries,
-      maxX,
+      maxX: displayedMaxX,
       yDomain: [0, paddedMax] as [number, number],
     };
   }, [actionCompletionCurves, actionId, selectedActionId, isHourly]);

--- a/server/src/analytics/analytics.service.ts
+++ b/server/src/analytics/analytics.service.ts
@@ -532,7 +532,6 @@ ORDER BY pp.total_session_duration_seconds DESC
 
     const isHourly = granularity === 'hourly';
     const msPerBucket = isHourly ? 60 * 60 * 1000 : msPerDay;
-    const maxBuckets = isHourly ? 168 : undefined; // 7 days * 24 hours
 
     return eligibleActions.map((record) => {
       const startDate = new Date(record.memberActionStartDate!);
@@ -541,13 +540,10 @@ ORDER BY pp.total_session_duration_seconds DESC
         : null;
       const endDate =
         plannedEndDate && plannedEndDate < now ? plannedEndDate : now;
-      let bucketCount = Math.max(
+      const bucketCount = Math.max(
         1,
         Math.ceil((endDate.getTime() - startDate.getTime()) / msPerBucket),
       );
-      if (maxBuckets !== undefined) {
-        bucketCount = Math.min(bucketCount, maxBuckets);
-      }
 
       const counts = new Array<number>(bucketCount).fill(0);
       const completions = completionsByActionId.get(record.actionId) ?? [];


### PR DESCRIPTION
Current behavior: end at 7 days (hard-coded)
Changes behavior to: end at time of action deadline

Also adds a filter to indicate which actions to include in the average trend CDF which defaults to +/- 3 days of this action's planned duration (or current duration if there's no planned duration).

I haven't tested this much because I'm too lazy to create actions and pretend to do them etc. so y'all should confirm this works properly in prod or staging if you have it. Worst case it breaks admin dashboard for a bit before you revert.

<img width="1420" height="599" alt="Screenshot 2026-04-20 at 16 58 51" src="https://github.com/user-attachments/assets/b340a927-0bbf-4c8f-af70-a33014508426" />