### PR TITLE
[ALL-886] Filtering on relation columns in DB viewer give exact match

### DIFF
--- a/server/src/admin-viewer/admin-viewer.service.ts
+++ b/server/src/admin-viewer/admin-viewer.service.ts
@@ -841,12 +841,20 @@ export class AdminViewerService {
         params.push(trimmedValue);
         return `"${column.name}"::text ILIKE $${params.length}`;
       }
+      case ColumnDataType.RELATION: {
+        const numericFk = Number(trimmedValue);
+        if (!Number.isNaN(numericFk) && Number.isInteger(numericFk)) {
+          params.push(numericFk);
+          return `"${column.name}" = $${params.length}`;
+        }
+        params.push(trimmedValue);
+        return `"${column.name}"::text = $${params.length}`;
+      }
       case ColumnDataType.DATE:
       case ColumnDataType.DATETIME:
       case ColumnDataType.JSON:
       case ColumnDataType.STRING:
-      case ColumnDataType.UNKNOWN:
-      case ColumnDataType.RELATION: {
+      case ColumnDataType.UNKNOWN: {
         params.push(`%${trimmedValue}%`);
         return `"${column.name}"::text ILIKE $${params.length}`;
       }

--- a/server/src/admin-viewer/admin-viewer.service.ts
+++ b/server/src/admin-viewer/admin-viewer.service.ts
@@ -842,6 +842,16 @@ export class AdminViewerService {
         return `"${column.name}"::text ILIKE $${params.length}`;
       }
       case ColumnDataType.RELATION: {
+        const parts = trimmedValue.split(',').map((p) => p.trim()).filter(Boolean);
+        if (parts.length > 1) {
+          const numerics = parts.map(Number);
+          if (numerics.every((n) => !Number.isNaN(n) && Number.isInteger(n))) {
+            const placeholders = numerics.map((n) => { params.push(n); return `$${params.length}`; });
+            return `"${column.name}" IN (${placeholders.join(', ')})`;
+          }
+          const placeholders = parts.map((p) => { params.push(p); return `$${params.length}`; });
+          return `"${column.name}"::text IN (${placeholders.join(', ')})`;
+        }
         const numericFk = Number(trimmedValue);
         if (!Number.isNaN(numericFk) && Number.isInteger(numericFk)) {
           params.push(numericFk);


### PR DESCRIPTION
E.g. `userid:10` now matches only userid = 10 and not userid = 102.

Also adds list matching for relation type columns, e.g. `userid:10,20,30`.