### PR TITLE
Scoll to top of next task form

### DIFF
--- a/apps/frontend/src/components/ActionTaskPanel.tsx
+++ b/apps/frontend/src/components/ActionTaskPanel.tsx
@@ -15,6 +15,7 @@ export type ActionTaskPanelProps = ActionTaskPanelPropsShared & {
   userRelation: UserActionRelation;
   missedDeadline?: boolean;
   card?: boolean;
+  onPageChange?: () => void;
 };
 
 const ActionTaskPanel: React.FC<ActionTaskPanelProps> = ({
@@ -24,6 +25,7 @@ const ActionTaskPanel: React.FC<ActionTaskPanelProps> = ({
   card = false,
   disabled = false,
   formResponse,
+  onPageChange,
 }: ActionTaskPanelProps) => {
   const handleCompleteAction = useCallback(() => {
     onCompleteAction();
@@ -96,6 +98,7 @@ const ActionTaskPanel: React.FC<ActionTaskPanelProps> = ({
           onAbandonAction={handleAbandonAction}
           card={card}
           actionId={action.id}
+          onPageChange={onPageChange}
         />
       );
     }

--- a/apps/frontend/src/components/ActionTaskPanel.tsx
+++ b/apps/frontend/src/components/ActionTaskPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, type RefObject } from "react";
 import ActionTaskPanelForm from "./ActionTaskPanelForm";
 // import ActionTaskPanelFunding from "./ActionTaskPanelFunding";
 // import { StripeWrapper } from "./StripeWrapper";
@@ -15,7 +15,7 @@ export type ActionTaskPanelProps = ActionTaskPanelPropsShared & {
   userRelation: UserActionRelation;
   missedDeadline?: boolean;
   card?: boolean;
-  onPageChange?: () => void;
+  scrollContainerRef?: RefObject<HTMLElement | null>;
 };
 
 const ActionTaskPanel: React.FC<ActionTaskPanelProps> = ({
@@ -25,7 +25,7 @@ const ActionTaskPanel: React.FC<ActionTaskPanelProps> = ({
   card = false,
   disabled = false,
   formResponse,
-  onPageChange,
+  scrollContainerRef,
 }: ActionTaskPanelProps) => {
   const handleCompleteAction = useCallback(() => {
     onCompleteAction();
@@ -98,7 +98,7 @@ const ActionTaskPanel: React.FC<ActionTaskPanelProps> = ({
           onAbandonAction={handleAbandonAction}
           card={card}
           actionId={action.id}
-          onPageChange={onPageChange}
+          scrollContainerRef={scrollContainerRef}
         />
       );
     }

--- a/apps/frontend/src/components/ActionTaskPanelForm.tsx
+++ b/apps/frontend/src/components/ActionTaskPanelForm.tsx
@@ -32,6 +32,7 @@ interface ActionTaskPanelFormProps {
   disabled?: boolean;
   publicAction?: boolean;
   formResponse?: FormResponseDto;
+  onPageChange?: () => void;
 }
 
 const ActionTaskPanelForm = ({
@@ -44,6 +45,7 @@ const ActionTaskPanelForm = ({
   disabled = false,
   publicAction = false,
   formResponse,
+  onPageChange,
 }: ActionTaskPanelFormProps) => {
   const [error, setError] = useState<string | null>(null);
   const { user, refreshUser } = useAuth();
@@ -185,6 +187,7 @@ const ActionTaskPanelForm = ({
           publicAction={publicAction}
           phDistinctId={distinctId}
           sessionReplayUrl={sessionReplayUrl}
+          onPageChange={onPageChange}
         />
       </div>
       {error && (

--- a/apps/frontend/src/components/ActionTaskPanelForm.tsx
+++ b/apps/frontend/src/components/ActionTaskPanelForm.tsx
@@ -11,7 +11,7 @@ import FormRenderer, {
 import { FormSchema } from "@alliance/common/forms/form-schema";
 import Card from "@alliance/sharedweb/ui/Card";
 import posthog from "posthog-js";
-import { useMemo, useState } from "react";
+import { useMemo, useState, type RefObject } from "react";
 import { useAuth } from "../lib/AuthContext";
 import Spinner from "@alliance/sharedweb/ui/Spinner";
 import { CardStyle } from "@alliance/shared/styles/card";
@@ -32,7 +32,7 @@ interface ActionTaskPanelFormProps {
   disabled?: boolean;
   publicAction?: boolean;
   formResponse?: FormResponseDto;
-  onPageChange?: () => void;
+  scrollContainerRef?: RefObject<HTMLElement | null>;
 }
 
 const ActionTaskPanelForm = ({
@@ -45,7 +45,7 @@ const ActionTaskPanelForm = ({
   disabled = false,
   publicAction = false,
   formResponse,
-  onPageChange,
+  scrollContainerRef,
 }: ActionTaskPanelFormProps) => {
   const [error, setError] = useState<string | null>(null);
   const { user, refreshUser } = useAuth();
@@ -187,7 +187,7 @@ const ActionTaskPanelForm = ({
           publicAction={publicAction}
           phDistinctId={distinctId}
           sessionReplayUrl={sessionReplayUrl}
-          onPageChange={onPageChange}
+          scrollContainerRef={scrollContainerRef}
         />
       </div>
       {error && (

--- a/apps/frontend/src/pages/app/HomePage.tsx
+++ b/apps/frontend/src/pages/app/HomePage.tsx
@@ -84,6 +84,7 @@ const HomePage = () => {
   }, [user, refreshUser]);
 
   const mainScrollRef = useRef<HTMLDivElement | null>(null);
+  const actionCardRef = useRef<HTMLDivElement | null>(null);
   const [actionProgressViews, setActionProgressViews] = useState<
     Record<number, AggregateViewSchema[]>
   >({});
@@ -436,42 +437,58 @@ const HomePage = () => {
 
           {selectedTaskNavigatorItem?.kind === "action" &&
           selectedTaskNavigatorItem.action.userRelation ? (
-            <LargeActionCard
-              action={selectedTaskNavigatorItem.action}
-              dismissProps={
-                taskDismissInfo
-                  ? {
-                      ...taskDismissInfo,
-                      onDismiss: () =>
-                        handleDismissAction(
-                          selectedTaskNavigatorItem.action.id,
-                        ),
-                    }
-                  : undefined
-              }
-              userRelation={selectedTaskNavigatorItem.action.userRelation}
-              onCompleteAction={() => {
-                queryClient.setQueryData<ActionDto[] | undefined>(
-                  ["actions"],
-                  (prev) =>
-                    prev?.map((action) =>
-                      action.id === selectedTaskNavigatorItem.action.id
-                        ? { ...action, userRelation: "completed" as const }
-                        : action,
-                    ),
-                );
-                queryClient.invalidateQueries({ queryKey: ["actions"] });
-              }}
-              onUpdateActionState={() => {
-                queryClient.invalidateQueries({ queryKey: ["actions"] });
-                mainScrollRef.current?.scrollTo({ top: 0, behavior: "auto" });
-                document.scrollingElement?.scrollTo({
-                  top: 0,
-                  behavior: "auto",
-                });
-                window.scrollTo({ top: 0, behavior: "auto" });
-              }}
-            />
+            <div ref={actionCardRef}>
+              <LargeActionCard
+                action={selectedTaskNavigatorItem.action}
+                dismissProps={
+                  taskDismissInfo
+                    ? {
+                        ...taskDismissInfo,
+                        onDismiss: () =>
+                          handleDismissAction(
+                            selectedTaskNavigatorItem.action.id,
+                          ),
+                      }
+                    : undefined
+                }
+                userRelation={selectedTaskNavigatorItem.action.userRelation}
+                onCompleteAction={() => {
+                  queryClient.setQueryData<ActionDto[] | undefined>(
+                    ["actions"],
+                    (prev) =>
+                      prev?.map((action) =>
+                        action.id === selectedTaskNavigatorItem.action.id
+                          ? { ...action, userRelation: "completed" as const }
+                          : action,
+                      ),
+                  );
+                  queryClient.invalidateQueries({ queryKey: ["actions"] });
+                }}
+                onUpdateActionState={() => {
+                  queryClient.invalidateQueries({ queryKey: ["actions"] });
+                  mainScrollRef.current?.scrollTo({ top: 0, behavior: "auto" });
+                  document.scrollingElement?.scrollTo({
+                    top: 0,
+                    behavior: "auto",
+                  });
+                  window.scrollTo({ top: 0, behavior: "auto" });
+                }}
+                onPageChange={() => {
+                  const card = actionCardRef.current;
+                  const scrollContainer = mainScrollRef.current;
+                  if (card && scrollContainer) {
+                    const cardTop =
+                      card.getBoundingClientRect().top -
+                      scrollContainer.getBoundingClientRect().top +
+                      scrollContainer.scrollTop;
+                    scrollContainer.scrollTo({
+                      top: cardTop,
+                      behavior: "instant",
+                    });
+                  }
+                }}
+              />
+            </div>
           ) : selectedTaskNavigatorItem?.kind === "followUpForm" ? (
             <div className="w-full mx-auto">
               <FollowUpFormPanel

--- a/apps/frontend/src/pages/app/HomePage.tsx
+++ b/apps/frontend/src/pages/app/HomePage.tsx
@@ -84,7 +84,6 @@ const HomePage = () => {
   }, [user, refreshUser]);
 
   const mainScrollRef = useRef<HTMLDivElement | null>(null);
-  const actionCardRef = useRef<HTMLDivElement | null>(null);
   const [actionProgressViews, setActionProgressViews] = useState<
     Record<number, AggregateViewSchema[]>
   >({});
@@ -437,58 +436,46 @@ const HomePage = () => {
 
           {selectedTaskNavigatorItem?.kind === "action" &&
           selectedTaskNavigatorItem.action.userRelation ? (
-            <div ref={actionCardRef}>
-              <LargeActionCard
-                action={selectedTaskNavigatorItem.action}
-                dismissProps={
-                  taskDismissInfo
-                    ? {
-                        ...taskDismissInfo,
-                        onDismiss: () =>
-                          handleDismissAction(
-                            selectedTaskNavigatorItem.action.id,
-                          ),
-                      }
-                    : undefined
-                }
-                userRelation={selectedTaskNavigatorItem.action.userRelation}
-                onCompleteAction={() => {
-                  queryClient.setQueryData<ActionDto[] | undefined>(
-                    ["actions"],
-                    (prev) =>
-                      prev?.map((action) =>
-                        action.id === selectedTaskNavigatorItem.action.id
-                          ? { ...action, userRelation: "completed" as const }
-                          : action,
-                      ),
-                  );
-                  queryClient.invalidateQueries({ queryKey: ["actions"] });
-                }}
-                onUpdateActionState={() => {
-                  queryClient.invalidateQueries({ queryKey: ["actions"] });
-                  mainScrollRef.current?.scrollTo({ top: 0, behavior: "auto" });
-                  document.scrollingElement?.scrollTo({
-                    top: 0,
-                    behavior: "auto",
-                  });
-                  window.scrollTo({ top: 0, behavior: "auto" });
-                }}
-                onPageChange={() => {
-                  const card = actionCardRef.current;
-                  const scrollContainer = mainScrollRef.current;
-                  if (card && scrollContainer) {
-                    const cardTop =
-                      card.getBoundingClientRect().top -
-                      scrollContainer.getBoundingClientRect().top +
-                      scrollContainer.scrollTop;
-                    scrollContainer.scrollTo({
-                      top: cardTop,
-                      behavior: "instant",
-                    });
-                  }
-                }}
-              />
-            </div>
+            <LargeActionCard
+              action={selectedTaskNavigatorItem.action}
+              dismissProps={
+                taskDismissInfo
+                  ? {
+                      ...taskDismissInfo,
+                      onDismiss: () =>
+                        handleDismissAction(
+                          selectedTaskNavigatorItem.action.id,
+                        ),
+                    }
+                  : undefined
+              }
+              userRelation={selectedTaskNavigatorItem.action.userRelation}
+              onCompleteAction={() => {
+                queryClient.setQueryData<ActionDto[] | undefined>(
+                  ["actions"],
+                  (prev) =>
+                    prev?.map((action) =>
+                      action.id === selectedTaskNavigatorItem.action.id
+                        ? { ...action, userRelation: "completed" as const }
+                        : action,
+                    ),
+                );
+                queryClient.invalidateQueries({ queryKey: ["actions"] });
+              }}
+              onUpdateActionState={() => {
+                queryClient.invalidateQueries({ queryKey: ["actions"] });
+                mainScrollRef.current?.scrollTo({
+                  top: 0,
+                  behavior: "instant",
+                });
+                document.scrollingElement?.scrollTo({
+                  top: 0,
+                  behavior: "instant",
+                });
+                window.scrollTo({ top: 0, behavior: "instant" });
+              }}
+              scrollContainerRef={mainScrollRef}
+            />
           ) : selectedTaskNavigatorItem?.kind === "followUpForm" ? (
             <div className="w-full mx-auto">
               <FollowUpFormPanel

--- a/apps/frontend/src/pages/app/LargeActionCard.tsx
+++ b/apps/frontend/src/pages/app/LargeActionCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type RefObject } from "react";
 import { href, useNavigate } from "react-router";
 import { cn } from "@alliance/shared/styles/util";
 import Button, { ButtonColor } from "@alliance/sharedweb/ui/Button";
@@ -22,7 +22,7 @@ export interface LargeActionCardProps extends LargeActionCardPropsShared {
   className?: string;
   onCompleteAction: () => void;
   userRelation: UserActionRelation;
-  onPageChange?: () => void;
+  scrollContainerRef?: RefObject<HTMLElement | null>;
 }
 
 enum LargeActionCardState {
@@ -43,7 +43,7 @@ const LargeActionCard: React.FC<LargeActionCardProps> = ({
   onCompleteAction,
   showDetails = true,
   className = "",
-  onPageChange,
+  scrollContainerRef,
 }: LargeActionCardProps) => {
   const navigate = useNavigate();
 
@@ -139,7 +139,7 @@ const LargeActionCard: React.FC<LargeActionCardProps> = ({
               userRelation={userRelation}
               onCompleteAction={handleCompleteAction}
               onOptOutAction={handleUpdateActionState}
-              onPageChange={onPageChange}
+              scrollContainerRef={scrollContainerRef}
             />
           </div>
         </div>

--- a/apps/frontend/src/pages/app/LargeActionCard.tsx
+++ b/apps/frontend/src/pages/app/LargeActionCard.tsx
@@ -22,6 +22,7 @@ export interface LargeActionCardProps extends LargeActionCardPropsShared {
   className?: string;
   onCompleteAction: () => void;
   userRelation: UserActionRelation;
+  onPageChange?: () => void;
 }
 
 enum LargeActionCardState {
@@ -42,6 +43,7 @@ const LargeActionCard: React.FC<LargeActionCardProps> = ({
   onCompleteAction,
   showDetails = true,
   className = "",
+  onPageChange,
 }: LargeActionCardProps) => {
   const navigate = useNavigate();
 
@@ -137,6 +139,7 @@ const LargeActionCard: React.FC<LargeActionCardProps> = ({
               userRelation={userRelation}
               onCompleteAction={handleCompleteAction}
               onOptOutAction={handleUpdateActionState}
+              onPageChange={onPageChange}
             />
           </div>
         </div>

--- a/sharedweb/forms/FormRenderer.tsx
+++ b/sharedweb/forms/FormRenderer.tsx
@@ -79,7 +79,7 @@ type FormRendererProps = {
   /** When set, previousAnswer blocks fetch this user's responses via the admin all-responses endpoint. */
   adminPreviewUserId?: string | number;
   onSubmit: ((data: SubmitFormDto) => Promise<void>) | null; // null for admin preview
-  onPageChange?: () => void;
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
 } & (
   | {
       isGeneralUpdate?: false;
@@ -167,7 +167,7 @@ const FormRenderer = ({
   sessionReplayUrl,
   isGeneralUpdate,
   onDismiss,
-  onPageChange,
+  scrollContainerRef,
 }: FormRendererProps) => {
   // Compute schema and a namespaced storage key for persistence (if enabled)
   const schema = form as unknown as FormSchema;
@@ -1335,18 +1335,35 @@ const FormRenderer = ({
 
   const prevPageIndexRef = useRef(currentPageIndex);
   useEffect(() => {
-    if (prevPageIndexRef.current !== currentPageIndex) {
-      prevPageIndexRef.current = currentPageIndex;
-      if (onPageChange) {
-        onPageChange();
-      } else {
-        formTopRef.current?.scrollIntoView({
-          behavior: "instant",
-          block: "start",
-        });
-      }
+    if (prevPageIndexRef.current === currentPageIndex) {
+      return;
     }
-  }, [currentPageIndex, onPageChange]);
+    prevPageIndexRef.current = currentPageIndex;
+    const container = scrollContainerRef?.current;
+    const top = formTopRef.current;
+    if (container && top) {
+      const rawScrollMarginTop = parseFloat(
+        getComputedStyle(top).scrollMarginTop,
+      );
+      const scrollMarginTop = Number.isFinite(rawScrollMarginTop)
+        ? rawScrollMarginTop
+        : 0;
+      const targetTop =
+        top.getBoundingClientRect().top -
+        container.getBoundingClientRect().top +
+        container.scrollTop -
+        scrollMarginTop;
+      container.scrollTo({
+        top: Math.max(0, targetTop),
+        behavior: "instant",
+      });
+    } else {
+      top?.scrollIntoView({
+        behavior: "instant",
+        block: "start",
+      });
+    }
+  }, [currentPageIndex]);
 
   const formTrackingParams = {
     formId: id,

--- a/sharedweb/forms/FormRenderer.tsx
+++ b/sharedweb/forms/FormRenderer.tsx
@@ -79,6 +79,7 @@ type FormRendererProps = {
   /** When set, previousAnswer blocks fetch this user's responses via the admin all-responses endpoint. */
   adminPreviewUserId?: string | number;
   onSubmit: ((data: SubmitFormDto) => Promise<void>) | null; // null for admin preview
+  onPageChange?: () => void;
 } & (
   | {
       isGeneralUpdate?: false;
@@ -166,6 +167,7 @@ const FormRenderer = ({
   sessionReplayUrl,
   isGeneralUpdate,
   onDismiss,
+  onPageChange,
 }: FormRendererProps) => {
   // Compute schema and a namespaced storage key for persistence (if enabled)
   const schema = form as unknown as FormSchema;
@@ -1335,12 +1337,16 @@ const FormRenderer = ({
   useEffect(() => {
     if (prevPageIndexRef.current !== currentPageIndex) {
       prevPageIndexRef.current = currentPageIndex;
-      formTopRef.current?.scrollIntoView({
-        behavior: "instant",
-        block: "start",
-      });
+      if (onPageChange) {
+        onPageChange();
+      } else {
+        formTopRef.current?.scrollIntoView({
+          behavior: "instant",
+          block: "start",
+        });
+      }
     }
-  }, [currentPageIndex]);
+  }, [currentPageIndex, onPageChange]);
 
   const formTrackingParams = {
     formId: id,


### PR DESCRIPTION
For a given task, when Form 1 is much longer than Form 2, clicking "next" ends up showing the "Activity" section of the page, and you have to scroll back up to see Form 2.

This PR: Clicking "next" and "previous" bring you back to the top of the action card, i.e. the title of the task.

---

I don't know if this is desired behavior, but it is a feature I was about to request on the Slack, until I realized I could request it via PR. Feel free to reject; I can think of reasons why we wouldn't want this.