### PR TITLE
[ALL-936] Fix previous answer block display in admin panel

### DIFF
--- a/apps/admin/src/pages/FormResponses.tsx
+++ b/apps/admin/src/pages/FormResponses.tsx
@@ -987,6 +987,7 @@ const FormResponses: React.FC = () => {
                           onSubmit={null}
                           userId={currentResponse?.user?.id}
                           user={currentResponse?.user ?? undefined}
+                          adminPreviewUserId={currentResponse?.user?.id}
                           disableOptionRandomization
                           fieldLabelRightContent={currentResponseAiInlineLabels}
                         />


### PR DESCRIPTION
It currently shows admin's previous answer rather than the user's. It should show the user's.