### PR TITLE
Distinguish action links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ In root dir: `bun install` (install [Bun](https://bun.sh) 1.3.x+ if missing; `pa
 `cp .env.example .env` (and make necessary edits)
 
 Install PostgreSQL 17:
+
 - **macOS (Homebrew):** `brew install postgresql@17 && brew services start postgresql@17`
 - **Ubuntu/Debian:** Add the [PGDG apt repository](https://www.postgresql.org/download/linux/debian/), then install:
   ```bash
@@ -40,9 +41,15 @@ Start the admin panel: `cd apps/admin && bun dev` (or `bun run admin:dev` from r
 
 ### server
 
-(First time only) install bun 1.3.6: `curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.6"`
+#### First time only:
+
+Install bun 1.3.6: `curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.6"` (If
+you have done [Setup - to install frontend deps](#setup) then `bun` will have already been installed.)
 
 Run the migrations: `(cd server && bun migration:run)`
+
+_Note_ if you get an error `role "postgres" does not exist`, first run `createuser -s postgres`.
+And if you get an error `database "alliance" does not exist`, first run `createdb alliance`.
 
 Start the server: `cd server && bun dev` (or `bun server:dev` from root dir)
 
@@ -51,6 +58,10 @@ When opening the app locally for the first time, you can log in with the account
 ### Loading data
 
 Developers often want to test local code with a cleaned version of the production database. To allow for this, we have a script, `./misc/load_staging_data.sh` that will copy the data from the staging server into the local postgres. For this to work, you first need to set up your `.ssh/config` with a `staging` destination with the appropriate ssh key (ask an existing developer for the keys / ip)
+
+### Viewing the database
+
+`psql alliance -U postgres`
 
 ### Mobile
 

--- a/apps/frontend/src/components/ActionContents.tsx
+++ b/apps/frontend/src/components/ActionContents.tsx
@@ -263,7 +263,10 @@ const ActionContents = () => {
           <>
             <div id="description">
               <p className="font-semibold text-xl mb-4">Description</p>
-              <AppMarkdownWrapper markdownContent={action?.body} />
+              <AppMarkdownWrapper
+                markdownContent={action?.body}
+                distinguishActionLinks={true}
+              />
             </div>
 
             {isAuthenticated && (

--- a/sharedweb/ui/AppMarkdownWrapper.tsx
+++ b/sharedweb/ui/AppMarkdownWrapper.tsx
@@ -2,17 +2,24 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { getApiUrl } from "../lib/config";
+import Link from "./Link";
 
 // TOOD add heading, body color enums
 
 interface AppMarkdownWrapperProps {
   markdownContent: string;
   className?: string;
+  /**
+   * if true, markdown links that match action link format will be rendered
+   * with an action link component instead of a standard anchor tag.
+   */
+  distinguishActionLinks?: boolean;
 }
 
 const AppMarkdownWrapper: React.FC<AppMarkdownWrapperProps> = ({
   markdownContent,
   className,
+  distinguishActionLinks,
 }) => {
   return (
     <div className={className}>
@@ -58,12 +65,7 @@ const AppMarkdownWrapper: React.FC<AppMarkdownWrapperProps> = ({
             <li className="first:mt-0 mt-2 pl-1 [&>p]:my-0" {...props} />
           ),
           a: ({ ...props }) => (
-            <a
-              className="text-link"
-              target="_blank"
-              rel="noreferrer"
-              {...props}
-            />
+            <Link distinguishActions={distinguishActionLinks} {...props} />
           ),
           blockquote: ({ ...props }) => (
             <blockquote

--- a/sharedweb/ui/Link.tsx
+++ b/sharedweb/ui/Link.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Layers } from "lucide-react";
+
+type LinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+  distinguishActions?: boolean;
+};
+
+export default function Link({ distinguishActions, ...props }: LinkProps) {
+  const hrefIsAction = distinguishActions && isHrefActionLink(props.href);
+
+  const { children, ...rest } = props;
+  return (
+    <a className="text-link" target="_blank" rel="noreferrer" {...rest}>
+      {children}
+      {hrefIsAction && (
+        <Layers
+          className="inline-block ml-1"
+          size={14}
+          style={{ margin: "-3px 0 0 3px" }}
+        />
+      )}
+    </a>
+  );
+}
+
+function isHrefActionLink(href: string | undefined): boolean {
+  if (!href) return false;
+  const url = new URL(href);
+  return !!url.pathname.match(/^\/actions\/\d+/);
+}


### PR DESCRIPTION
Adds a new UI component `<Link />`. `Link` takes an optional `distinguishActions` boolean which when true and given an href to an action on the Alliance website, will render an anchor tag with a custom symbol to indicate that this link is to action:

<img width="455" height="190" alt="image" src="https://github.com/user-attachments/assets/626e26a3-11c0-4350-83a9-e712fe794cf9" />

Note that links to external pages and non-action Alliance pages remain the same.

Secondly this PR uses this new `Link` component to render action links for any link in the action description text, e.g. for pages like `/actions/1` in `components/ActionContents`.