### PR TITLE
Distinguish action references and add hover previews

### DIFF
--- a/apps/frontend/src/stories/ActionLink.stories.tsx
+++ b/apps/frontend/src/stories/ActionLink.stories.tsx
@@ -1,0 +1,125 @@
+import { ActionDto } from "@alliance/shared/client";
+import AppMarkdownWrapper from "@alliance/sharedweb/ui/AppMarkdownWrapper";
+import { Meta, StoryObj } from "@storybook/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Flag, Layers, Megaphone, Target } from "lucide-react";
+import React from "react";
+import { testActions } from "./testData";
+
+const inDays = (n: number) => new Date(Date.now() + n * 86_400_000).toISOString();
+
+/** Actions tailored to exercise the preview: thumbnail, live deadline, completed state. */
+const previewActions: ActionDto[] = [
+  {
+    ...testActions[0],
+    id: 1,
+    type: "Activity",
+    status: "member_action",
+    usersCompleted: 157,
+    events: [
+      {
+        id: 91,
+        title: "Deadline",
+        description: "",
+        date: inDays(3),
+        newStatus: "resolution",
+        suiteManaged: false,
+      },
+    ],
+  },
+  {
+    ...testActions[1],
+    id: 2,
+    type: "Funding",
+    status: "member_action",
+    donationAmount: 1000,
+    usersCompleted: 57,
+    userRelation: "completed",
+    events: [],
+  },
+];
+
+/**
+ * Seed the query cache so the hover preview renders the example actions
+ * without a live backend. The key must match `ActionLink`'s queryKey.
+ */
+function makeSeededClient() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { staleTime: Infinity, retry: false } },
+  });
+  for (const action of previewActions) {
+    client.setQueryData(["actionLinkPreview", action.id], action);
+  }
+  return client;
+}
+
+const withSeededQueryClient = (Story: React.ComponentType) => (
+  <QueryClientProvider client={makeSeededClient()}>
+    <div className="max-w-prose p-8 text-base text-zinc-900">
+      <Story />
+    </div>
+  </QueryClientProvider>
+);
+
+const meta = {
+  title: "Alliance/ActionLink",
+  component: AppMarkdownWrapper,
+  tags: ["component"],
+  parameters: { layout: "centered" },
+  decorators: [withSeededQueryClient],
+} satisfies Meta<typeof AppMarkdownWrapper>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** An action reference inside a paragraph — hover the link to see the preview. */
+export const Inline: Story = {
+  args: {
+    markdownContent:
+      "We've made real progress this month. If you haven't yet, " +
+      "[help save the Ecuador cloud forest](/actions/1) — it only takes a " +
+      "few minutes. You can also [pressure Target on single-use plastics]" +
+      "(/actions/2) and read more on [our website](https://worldalliance.org).",
+  },
+};
+
+/** Several action references in a list, mixed with a normal link. */
+export const InList: Story = {
+  args: {
+    markdownContent: [
+      "This action builds on a few others:",
+      "",
+      "- [Save the Ecuador cloud forest](/actions/1)",
+      "- [Make Target end single-use plastics](/actions/2)",
+      "- [An external reference](https://example.org)",
+    ].join("\n"),
+  },
+};
+
+/** Side-by-side comparison of candidate marker glyphs (no hover needed). */
+export const GlyphComparison: Story = {
+  args: { markdownContent: "" },
+  render: () => {
+    const glyphs: [string, React.ComponentType<{ size?: number; style?: React.CSSProperties }>][] =
+      [
+        ["Flag", Flag],
+        ["Target", Target],
+        ["Megaphone", Megaphone],
+        ["Layers (current nav icon)", Layers],
+      ];
+    return (
+      <div className="flex flex-col gap-y-3">
+        {glyphs.map(([name, Icon]) => (
+          <p key={name}>
+            Help us{" "}
+            <span className="text-link">
+              save the Ecuador cloud forest
+              <Icon size={13} style={{ margin: "-3px 0 0 3px", display: "inline-block" }} />
+            </span>{" "}
+            <span className="text-zinc-400">— {name}</span>
+          </p>
+        ))}
+      </div>
+    );
+  },
+};

--- a/sharedweb/ui/ActionLink.tsx
+++ b/sharedweb/ui/ActionLink.tsx
@@ -1,0 +1,80 @@
+import { cn } from "@alliance/shared/styles/util";
+import { Flag } from "lucide-react";
+import React from "react";
+
+/**
+ * Glyph used to mark an action link. A flag reads as "a cause to rally to",
+ * which fits an Alliance action better than a generic link. Swap here to
+ * restyle every action link platform-wide.
+ */
+const ActionIcon = Flag;
+
+/**
+ * Extract an action id from a link href. Handles both relative
+ * (`/actions/92`, `/action/92`) and absolute (`https://worldalliance.org/actions/92`)
+ * forms. Returns null when the href is not an action link.
+ */
+export function getActionIdFromHref(href: string | undefined): number | null {
+  if (!href) return null;
+  let pathname = href;
+  if (!href.startsWith("/")) {
+    try {
+      pathname = new URL(href).pathname;
+    } catch {
+      return null;
+    }
+  }
+  const match = pathname.match(/^\/actions?\/(\d+)(?:\/|$|\?|#)/);
+  return match ? Number(match[1]) : null;
+}
+
+type ActionLinkProps = Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  "ref"
+> & {
+  /** mdast node passed by react-markdown; discarded so it isn't spread to the DOM */
+  node?: unknown;
+};
+
+/**
+ * Renders a reference to an action as an inline link, visually distinguished
+ * with a small flag icon. Falls back to a plain link when the href is not an
+ * action link.
+ */
+export default function ActionLink({
+  node: _node,
+  href,
+  children,
+  className,
+  ...rest
+}: ActionLinkProps) {
+  const actionId = getActionIdFromHref(href);
+
+  if (actionId == null) {
+    return (
+      <a className={cn("text-link", className)} href={href} {...rest}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      rel="noreferrer"
+      className={cn(
+        "text-link inline whitespace-normal underline-offset-2",
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+      <ActionIcon
+        className="inline-block shrink-0"
+        size={13}
+        style={{ margin: "-3px 0 0 3px" }}
+        aria-hidden
+      />
+    </a>
+  );
+}

--- a/sharedweb/ui/ActionLink.tsx
+++ b/sharedweb/ui/ActionLink.tsx
@@ -46,12 +46,12 @@ const STATUS_META: Record<
   draft: null,
   planned: { label: "Planned", className: "bg-blue-50 text-blue-700" },
   office_action: { label: "Underway", className: "bg-amber-50 text-amber-700" },
-  member_action: { label: "Open now", className: "bg-green-50 text-green-700" },
+  member_action: { label: "Open now", className: "bg-green/10 text-green" },
   resolution: {
     label: "In resolution",
     className: "bg-amber-50 text-amber-700",
   },
-  completed: { label: "Completed", className: "bg-green-50 text-green-700" },
+  completed: { label: "Completed", className: "bg-green/10 text-green" },
   failed: { label: "Failed", className: "bg-red-50 text-red-600" },
   abandoned: { label: "Abandoned", className: "bg-zinc-100 text-zinc-500" },
 };
@@ -124,7 +124,11 @@ export default function ActionLink({
           aria-hidden
         />
       </HoverCardTrigger>
-      <HoverCardContent side="top" sideOffset={6} className="overflow-hidden p-0">
+      <HoverCardContent
+        side="top"
+        sideOffset={6}
+        className="overflow-hidden p-0"
+      >
         <ActionPreviewBody data={data} isError={isError} />
       </HoverCardContent>
     </HoverCard>
@@ -187,7 +191,7 @@ function ActionPreviewCard({ action }: { action: ActionDto }) {
       )}
       <ActionPreviewMeta action={action} nextEvent={nextEvent} />
       {completed && (
-        <span className="mt-0.5 flex items-center gap-x-1 text-[11px] font-medium text-green-700">
+        <span className="mt-0.5 flex items-center gap-x-1 text-[11px] font-medium text-green">
           <CheckCircle2 size={12} className="shrink-0" />
           You&apos;ve completed this
         </span>
@@ -217,7 +221,8 @@ function ActionPreviewMeta({
   if (action.type === "Funding" && action.donationAmount) {
     items.push(
       <span key="donation" className="flex items-center gap-x-1">
-        <Coins size={12} className="shrink-0" />${(action.donationAmount / 100).toFixed(0)} suggested
+        <Coins size={12} className="shrink-0" />$
+        {(action.donationAmount / 100).toFixed(0)} suggested
       </span>,
     );
   } else if (nextEvent) {

--- a/sharedweb/ui/ActionLink.tsx
+++ b/sharedweb/ui/ActionLink.tsx
@@ -1,6 +1,17 @@
+import {
+  ActionDto,
+  ActionEventDto,
+  ActionStatus,
+  actionsFindOne,
+} from "@alliance/shared/client";
+import { formatNextTaskDue } from "@alliance/shared/lib/formatNextTaskDue";
+import { getNextEvent } from "@alliance/shared/lib/largeActionCard";
+import { deadlineColor } from "@alliance/shared/lib/taskTimeInfo";
 import { cn } from "@alliance/shared/styles/util";
-import { Flag } from "lucide-react";
-import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { CheckCircle2, Clock, Coins, Flag, Users } from "lucide-react";
+import React, { useState } from "react";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "./HoverCard";
 
 /**
  * Glyph used to mark an action link. A flag reads as "a cause to rally to",
@@ -28,6 +39,23 @@ export function getActionIdFromHref(href: string | undefined): number | null {
   return match ? Number(match[1]) : null;
 }
 
+const STATUS_META: Record<
+  ActionStatus,
+  { label: string; className: string } | null
+> = {
+  draft: null,
+  planned: { label: "Planned", className: "bg-blue-50 text-blue-700" },
+  office_action: { label: "Underway", className: "bg-amber-50 text-amber-700" },
+  member_action: { label: "Open now", className: "bg-green-50 text-green-700" },
+  resolution: {
+    label: "In resolution",
+    className: "bg-amber-50 text-amber-700",
+  },
+  completed: { label: "Completed", className: "bg-green-50 text-green-700" },
+  failed: { label: "Failed", className: "bg-red-50 text-red-600" },
+  abandoned: { label: "Abandoned", className: "bg-zinc-100 text-zinc-500" },
+};
+
 type ActionLinkProps = Omit<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
   "ref"
@@ -38,8 +66,10 @@ type ActionLinkProps = Omit<
 
 /**
  * Renders a reference to an action as an inline link, visually distinguished
- * with a small flag icon. Falls back to a plain link when the href is not an
- * action link.
+ * with a small icon, and shows a hover preview with enough context to
+ * understand the action without navigating to it.
+ *
+ * Falls back to a plain link when the href is not an action link.
  */
 export default function ActionLink({
   node: _node,
@@ -49,6 +79,22 @@ export default function ActionLink({
   ...rest
 }: ActionLinkProps) {
   const actionId = getActionIdFromHref(href);
+  const [open, setOpen] = useState(false);
+
+  const { data, isError } = useQuery({
+    queryKey: ["actionLinkPreview", actionId],
+    queryFn: async () => {
+      const res = await actionsFindOne({ path: { id: actionId! } });
+      if (!res.data) {
+        throw new Error("Failed to load action preview");
+      }
+      return res.data;
+    },
+    // Only fetch once the user actually hovers, so a page full of action
+    // links doesn't fan out into a request per link on mount.
+    enabled: open && actionId != null,
+    staleTime: 5 * 60 * 1000,
+  });
 
   if (actionId == null) {
     return (
@@ -59,22 +105,146 @@ export default function ActionLink({
   }
 
   return (
-    <a
-      href={href}
-      rel="noreferrer"
-      className={cn(
-        "text-link inline whitespace-normal underline-offset-2",
-        className,
+    <HoverCard open={open} onOpenChange={setOpen}>
+      <HoverCardTrigger
+        href={href}
+        delay={250}
+        closeDelay={100}
+        className={cn(
+          "text-link inline whitespace-normal underline-offset-2",
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+        <ActionIcon
+          className="inline-block shrink-0"
+          size={13}
+          style={{ margin: "-3px 0 0 3px" }}
+          aria-hidden
+        />
+      </HoverCardTrigger>
+      <HoverCardContent side="top" sideOffset={6} className="overflow-hidden p-0">
+        <ActionPreviewBody data={data} isError={isError} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+function ActionPreviewBody({
+  data,
+  isError,
+}: {
+  data: ActionDto | undefined;
+  isError: boolean;
+}) {
+  if (data) {
+    return <ActionPreviewCard action={data} />;
+  }
+  if (isError) {
+    return (
+      <div className="w-72 p-3 text-sm text-zinc-500">
+        Couldn&apos;t load this action.
+      </div>
+    );
+  }
+  // loading / not-yet-fetched skeleton
+  return (
+    <div className="w-72 animate-pulse p-3" aria-hidden>
+      <div className="mb-2 h-3.5 w-3/4 rounded bg-zinc-200" />
+      <div className="mb-1.5 h-2.5 w-full rounded bg-zinc-100" />
+      <div className="h-2.5 w-5/6 rounded bg-zinc-100" />
+    </div>
+  );
+}
+
+function ActionPreviewCard({ action }: { action: ActionDto }) {
+  const status = STATUS_META[action.status];
+  const nextEvent = getNextEvent(action);
+  const completed = action.userRelation === "completed";
+
+  return (
+    <div className="flex w-72 flex-col gap-y-1 p-3 text-left">
+      <div className="flex items-start justify-between gap-x-2">
+        <p className="line-clamp-2 text-sm font-semibold text-zinc-900">
+          {action.name}
+        </p>
+        {status && (
+          <span
+            className={cn(
+              "mt-0.5 shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium",
+              status.className,
+            )}
+          >
+            {status.label}
+          </span>
+        )}
+      </div>
+      {action.shortDescription && (
+        <p className="line-clamp-3 text-xs leading-relaxed text-zinc-600">
+          {action.shortDescription}
+        </p>
       )}
-      {...rest}
-    >
-      {children}
-      <ActionIcon
-        className="inline-block shrink-0"
-        size={13}
-        style={{ margin: "-3px 0 0 3px" }}
-        aria-hidden
-      />
-    </a>
+      <ActionPreviewMeta action={action} nextEvent={nextEvent} />
+      {completed && (
+        <span className="mt-0.5 flex items-center gap-x-1 text-[11px] font-medium text-green-700">
+          <CheckCircle2 size={12} className="shrink-0" />
+          You&apos;ve completed this
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ActionPreviewMeta({
+  action,
+  nextEvent,
+}: {
+  action: ActionDto;
+  nextEvent: ActionEventDto | null;
+}) {
+  const items: React.ReactNode[] = [];
+
+  if (action.usersCompleted > 0) {
+    items.push(
+      <span key="completed" className="flex items-center gap-x-1">
+        <Users size={12} className="shrink-0" />
+        {action.usersCompleted.toLocaleString()} completed
+      </span>,
+    );
+  }
+
+  if (action.type === "Funding" && action.donationAmount) {
+    items.push(
+      <span key="donation" className="flex items-center gap-x-1">
+        <Coins size={12} className="shrink-0" />${(action.donationAmount / 100).toFixed(0)} suggested
+      </span>,
+    );
+  } else if (nextEvent) {
+    items.push(
+      <span
+        key="deadline"
+        className="flex items-center gap-x-1"
+        style={{ color: deadlineColor(nextEvent, action) }}
+      >
+        <Clock size={12} className="shrink-0" />
+        {formatNextTaskDue(new Date(nextEvent.date).getTime())}
+      </span>,
+    );
+  } else if (action.timeEstimate) {
+    items.push(
+      <span key="time" className="flex items-center gap-x-1">
+        <Clock size={12} className="shrink-0" />
+        {action.timeEstimate} min
+      </span>,
+    );
+  }
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] font-medium text-zinc-500">
+      {items}
+    </div>
   );
 }

--- a/sharedweb/ui/AppMarkdownWrapper.tsx
+++ b/sharedweb/ui/AppMarkdownWrapper.tsx
@@ -2,16 +2,19 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { getApiUrl } from "../lib/config";
+import ActionLink, { getActionIdFromHref } from "./ActionLink";
 import Link from "./Link";
 
 // TOOD add heading, body color enums
 
-interface AppMarkdownWrapperProps {
+export interface AppMarkdownWrapperProps {
   markdownContent: string;
   className?: string;
   /**
-   * if true, markdown links that match action link format will be rendered
-   * with an action link component instead of a standard anchor tag.
+   * When true (the default), markdown links that point to an action are
+   * rendered with {@link ActionLink} — visually distinguished and with a hover
+   * preview — instead of a standard anchor tag. Set to false to opt a surface
+   * out (e.g. where an action preview would be noise).
    */
   distinguishActionLinks?: boolean;
 }
@@ -19,7 +22,7 @@ interface AppMarkdownWrapperProps {
 const AppMarkdownWrapper: React.FC<AppMarkdownWrapperProps> = ({
   markdownContent,
   className,
-  distinguishActionLinks,
+  distinguishActionLinks = true,
 }) => {
   return (
     <div className={className}>
@@ -64,9 +67,13 @@ const AppMarkdownWrapper: React.FC<AppMarkdownWrapperProps> = ({
           li: ({ ...props }) => (
             <li className="first:mt-0 mt-2 pl-1 [&>p]:my-0" {...props} />
           ),
-          a: ({ ...props }) => (
-            <Link distinguishActions={distinguishActionLinks} {...props} />
-          ),
+          a: ({ node: _node, ...props }) =>
+            distinguishActionLinks &&
+            getActionIdFromHref(props.href) != null ? (
+              <ActionLink {...props} />
+            ) : (
+              <Link {...props} />
+            ),
           blockquote: ({ ...props }) => (
             <blockquote
               className="border-l-2 border-gray-300 pl-4 my-4"

--- a/sharedweb/ui/Link.tsx
+++ b/sharedweb/ui/Link.tsx
@@ -1,30 +1,14 @@
 import React from "react";
-import { Layers } from "lucide-react";
 
 type LinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
-  distinguishActions?: boolean;
+  /** mdast node passed by react-markdown; discarded so it isn't spread to the DOM */
+  node?: unknown;
 };
 
-export default function Link({ distinguishActions, ...props }: LinkProps) {
-  const hrefIsAction = distinguishActions && isHrefActionLink(props.href);
-
-  const { children, ...rest } = props;
+export default function Link({ node: _node, children, ...rest }: LinkProps) {
   return (
     <a className="text-link" target="_blank" rel="noreferrer" {...rest}>
       {children}
-      {hrefIsAction && (
-        <Layers
-          className="inline-block ml-1"
-          size={14}
-          style={{ margin: "-3px 0 0 3px" }}
-        />
-      )}
     </a>
   );
-}
-
-function isHrefActionLink(href: string | undefined): boolean {
-  if (!href) return false;
-  const url = new URL(href);
-  return !!url.pathname.match(/^\/actions\/\d+/);
 }


### PR DESCRIPTION
## What
Action links in authored content (action bodies, updates, comments, messages, bios) now carry a flag icon and show a preview on hover — so you can tell what an action is without clicking through. Most visible on an action whose body references several other actions.

## Design
- **Flag icon, link stays green.** An action is a cause to rally to - flag seemed fitting. The colour doesn't change, so references read inline instead of shouting. The flag alone separates actions from external links, which stay plain.
- **Preview answers "what is this, should I act?"** Title, status ("Open now" / "Completed"), a few lines of description, then completions and deadline (turns red inside 48h),  or suggested donation for funding actions. "✓ You've completed this" if you have.
- **One wiring point.** Routed through the shared `AppMarkdownWrapper` (on by default), so it lights up everywhere actions are referenced in prose. Opt out with `distinguishActionLinks={false}`.

## Considerations
Alternatives we weighed and set aside:
- **Glyph.** Looked at the `Layers` icon (already "Actions" in the sidebar nav, not sure whether that means it should have been chosen or avoided) and target/megaphone. Flag read most like "a cause to join."
- **How to distinguish.** Considered a separate link colour for actions, or inverting it Wikipedia-style to mark the rarer *external* links instead. Kept icon-only as the lowest-noise option.
- **Image in the preview.** Prototyped a thumbnail, then cut it. Slowest part to load and the least useful per pixel.
- **Left out.** A CTA button and author avatars, to keep the card scannable; short status labels ("Open now") over the platform's longer `actionStatusDescriptions` (easy to switch).

## Scope
Web only. Mobile has no hover and its own markdown engine. No backend changes. 

## Performance Impact
The fetch is lazy and cached, so a page full of links makes at most one request per action.

## Note
The shared link component opens every markdown link in a new tab (`target="_blank"`). For internal action links that looks unintentional, so I addressed that. 

Trivial to revert if my intuition was wrong on that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown links to actions now show interactive hover previews with name, status, description, completion/funding metadata, and upcoming deadline or estimate.
* **Behavior Change**
  * Markdown rendering now automatically distinguishes and renders action links inline when applicable.
* **UI / Previews**
  * Added Storybook examples demonstrating inline, list, and icon-comparison views for action links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->