### PR TITLE
Report the prod → staging sync to Slack and a dead man's switch

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -179,6 +179,8 @@ For node-exporter, we need to update `prometheus.yml` on the monitoring instance
 
 Slack covers the runs that live long enough to post. The switch covers the ones that don't: a SIGKILL, a dead host, a cron that never fires, a `db-sync.env` that won't source. All of those send nothing, and the check alerts on the ping that never arrives.
 
+The start and the outcome carry the run's timestamp, as in `prod → staging (20260901_020000)`, which is how you tell which start an outcome belongs to hours later. That same string names the dump file in the host log, so a message in Slack leads to its own lines in the log. A failure before the sync starts has no start to pair with and posts untagged.
+
 Use a healthchecks.io check and set `HEALTHCHECK_URL` in `/home/ec2-user/db-sync.env` to its bare ping URL. The script appends `/start` and `/fail` itself, so don't include either, and a trailing slash is fine. Give the check a period of a day and a grace window longer than a full sync takes. A Better Stack heartbeat is not a drop-in replacement. It takes the bare URL and `/fail`, with no `/start`.
 
 The sync refuses to start without `HEALTHCHECK_URL` and posts an `:x:` to Slack saying so. That is on purpose. A monitor that turns itself off when someone forgets a variable is worse than no monitor. It does mean a freshly provisioned staging host needs the variable in `db-sync.env` before the first run, not after.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -182,3 +182,5 @@ Slack covers the runs that live long enough to post. The switch covers the ones 
 Use a healthchecks.io check and set `HEALTHCHECK_URL` in `/home/ec2-user/db-sync.env` to its bare ping URL. The script appends `/start` and `/fail` itself, so don't include either, and a trailing slash is fine. Give the check a period of a day and a grace window longer than a full sync takes. A Better Stack heartbeat is not a drop-in replacement. It takes the bare URL and `/fail`, with no `/start`.
 
 The sync refuses to start without `HEALTHCHECK_URL` and posts an `:x:` to Slack saying so. That is on purpose. A monitor that turns itself off when someone forgets a variable is worse than no monitor. It does mean a freshly provisioned staging host needs the variable in `db-sync.env` before the first run, not after.
+
+Runs serialize on `/home/ec2-user/sync_prod_to_staging.lock`, so a manual re-run that collides with the nightly cron posts a `:no_entry:` and exits 0 instead of racing it over the same databases. The host needs `flock` for that. Without it the sync refuses to start and says so in Slack.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -172,3 +172,13 @@ sudo systemctl status node_exporter
 ```
 
 For node-exporter, we need to update `prometheus.yml` on the monitoring instance with the ips (local to the network) of all the instances we want to fetch node-exporter data from.
+
+## prod → staging sync
+
+`scripts/sync_prod_to_staging.sh` runs nightly from cron on the staging host, and the backend deploy reinstalls it as `~/sync_prod_to_staging.sh` on every non-production branch. It reports each run twice, to Slack and to a dead man's switch.
+
+Slack covers the runs that live long enough to post. The switch covers the ones that don't: a SIGKILL, a dead host, a cron that never fires, a `db-sync.env` that won't source. All of those send nothing, and the check alerts on the ping that never arrives.
+
+Use a healthchecks.io check and set `HEALTHCHECK_URL` in `/home/ec2-user/db-sync.env` to its bare ping URL. The script appends `/start` and `/fail` itself, so don't include either, and a trailing slash is fine. Give the check a period of a day and a grace window longer than a full sync takes. A Better Stack heartbeat is not a drop-in replacement. It takes the bare URL and `/fail`, with no `/start`.
+
+The sync refuses to start without `HEALTHCHECK_URL` and posts an `:x:` to Slack saying so. That is on purpose. A monitor that turns itself off when someone forgets a variable is worse than no monitor. It does mean a freshly provisioned staging host needs the variable in `db-sync.env` before the first run, not after.

--- a/scripts/sync_prod_to_staging.sh
+++ b/scripts/sync_prod_to_staging.sh
@@ -17,8 +17,17 @@ if ! command -v jq >/dev/null; then
   exit 1
 fi
 
+# The lock taken below lives on the open file description rather than the
+# process, so every child inherits it and an orphaned pg_dump would hold it
+# after a kill and skip every run that follows. Anything that can outlive the
+# shell runs through here. The two startup aborts below run before the lock
+# exists, where closing an fd nothing opened is a no-op.
+unlocked() {
+  "$@" 200>&-
+}
+
 notify_slack() {
-  curl --silent --show-error --fail --max-time 10 \
+  unlocked curl --silent --show-error --fail --max-time 10 \
     --retry 3 --retry-connrefused \
     --header 'Content-Type: application/json' \
     --data "$(jq -nc --arg text "$1" '{text: $text}')" \
@@ -35,15 +44,44 @@ notify_slack() {
 ping_healthcheck() {
   local base="${HEALTHCHECK_URL:-}"
   [ -n "$base" ] || return 0
-  curl --silent --show-error --fail --max-time 10 \
+  unlocked curl --silent --show-error --fail --max-time 10 \
     --retry 3 --retry-connrefused --retry-max-time 30 \
     "${base%/}${1:-}" >/dev/null \
     || echo "[$(date)] ==> WARNING: could not ping the healthcheck."
 }
 
+# The startup trap is installed below, so a failure up here reports for itself.
+abort_before_start() {
+  echo "[$(date)] ==> $1" >&2
+  notify_slack ":x: prod → staging: $1"
+  ping_healthcheck /fail
+  exit 1
+}
+
+if ! command -v flock >/dev/null; then
+  abort_before_start "flock is not installed; the sync needs it to stop two \
+runs from overlapping."
+fi
+
+LOCK_FILE=/home/ec2-user/sync_prod_to_staging.lock
+if ! true >>"$LOCK_FILE"; then
+  abort_before_start "cannot write ${LOCK_FILE}; the sync needs it to stop two \
+runs from overlapping."
+fi
+
+# Two runs share one scratch database and one staging database, so an overlap
+# corrupts both, and in the worst order one run renames the other's
+# half-restored, still unanonymized database into place as staging.
+exec 200>>"$LOCK_FILE"
+if ! flock -n 200; then
+  echo "[$(date)] ==> Another sync is already running; skipping this one."
+  notify_slack ":no_entry: prod → staging: another sync is already running; \
+skipping this one."
+  exit 0
+fi
+
 # cleanup reads paths built further down, so it can't be the trap yet. This one
-# reports the only startup failure that can reach Slack, a db-sync.env that
-# loads but is missing a variable.
+# reports a db-sync.env that loads but is missing a variable.
 report_startup_failure() {
   notify_slack ":x: prod → staging: FAILED during startup, before the sync \
 began. Check db-sync.env on the staging host. Staging still holds the data from \
@@ -88,8 +126,9 @@ cleanup() {
   rm -f "$DUMP_FILE"
 
   if [ "$SWAP_STARTED" -eq 0 ]; then
-    psql "$STAGING_ADMIN_URL" -q \
-      -c "DROP DATABASE IF EXISTS ${SCRATCH_DB} WITH (FORCE);" >/dev/null 2>&1 \
+    unlocked psql "$STAGING_ADMIN_URL" -q \
+      -c "DROP DATABASE IF EXISTS ${SCRATCH_DB} WITH (FORCE);" \
+      >/dev/null 2>&1 \
       || echo "[$(date)] ==> WARNING: could not drop ${SCRATCH_DB}; it may still" \
         "hold unanonymized prod data."
   fi
@@ -139,7 +178,7 @@ ping_healthcheck /start
 STAGE="dump"
 echo "[$(date)] ==> Dumping prod database to ${DUMP_FILE}..."
 
-pg_dump \
+unlocked pg_dump \
   --format=custom \
   --no-owner \
   --no-privileges \
@@ -149,7 +188,7 @@ pg_dump \
 STAGE="scratch database"
 echo "[$(date)] ==> Recreating scratch database ${SCRATCH_DB}..."
 
-psql "$STAGING_ADMIN_URL" -v ON_ERROR_STOP=1 <<SQL
+unlocked psql "$STAGING_ADMIN_URL" -v ON_ERROR_STOP=1 <<SQL
 DROP DATABASE IF EXISTS ${SCRATCH_DB} WITH (FORCE);
 CREATE DATABASE ${SCRATCH_DB} WITH TEMPLATE=template0 ENCODING='UTF8';
 SQL
@@ -157,7 +196,7 @@ SQL
 STAGE="restore"
 echo "[$(date)] ==> Restoring dump into ${SCRATCH_DB}..."
 
-pg_restore \
+unlocked pg_restore \
   --exit-on-error \
   --no-owner \
   --no-privileges \
@@ -167,7 +206,7 @@ pg_restore \
 STAGE="anonymize"
 echo "[$(date)] ==> Anonymizing ${SCRATCH_DB}..."
 
-psql "$SCRATCH_URL" -v ON_ERROR_STOP=1 --single-transaction \
+unlocked psql "$SCRATCH_URL" -v ON_ERROR_STOP=1 --single-transaction \
   -v password_hash="$STAGING_PASSWORD_HASH" <<'SQL'
 -- ============================================================================
 -- Anonymize members.
@@ -312,7 +351,7 @@ STAGE="swap"
 echo "[$(date)] ==> Swapping ${SCRATCH_DB} into place as ${STAGING_DB_NAME}..."
 
 SWAP_STARTED=1
-psql "$STAGING_ADMIN_URL" -v ON_ERROR_STOP=1 <<SQL
+unlocked psql "$STAGING_ADMIN_URL" -v ON_ERROR_STOP=1 <<SQL
 SELECT pg_terminate_backend(pid)
 FROM pg_stat_activity
 WHERE datname = '${SCRATCH_DB}'
@@ -325,7 +364,7 @@ SQL
 STAGE="s3 sync"
 echo "[$(date)] ==> S3 sync s3://$PROD_ASSETS_BUCKET -> s3://$STAGING_ASSETS_BUCKET"
 
-aws s3 sync \
+unlocked aws s3 sync \
   "s3://${PROD_ASSETS_BUCKET}/" \
   "s3://${STAGING_ASSETS_BUCKET}/" \
   --only-show-errors \

--- a/scripts/sync_prod_to_staging.sh
+++ b/scripts/sync_prod_to_staging.sh
@@ -81,7 +81,7 @@ skipping this one."
 fi
 
 # cleanup reads paths built further down, so it can't be the trap yet. This one
-# reports a db-sync.env that loads but is missing a variable.
+# reports a db-sync.env that loads but doesn't hold what the sync needs.
 report_startup_failure() {
   notify_slack ":x: prod → staging: FAILED during startup, before the sync \
 began. Check db-sync.env on the staging host. Staging still holds the data from \
@@ -103,6 +103,13 @@ trap report_startup_failure EXIT
   "${PROD_ASSETS_BUCKET:?missing in db-sync.env}" \
   "${STAGING_ASSETS_BUCKET:?missing in db-sync.env}" \
   "${HEALTHCHECK_URL:?missing in db-sync.env}"
+
+BCRYPT_PATTERN='^\$2[aby]\$[0-9]{2}\$[./A-Za-z0-9]{53}$'
+if [[ ! $STAGING_PASSWORD_HASH =~ $BCRYPT_PATTERN ]]; then
+  echo "STAGING_PASSWORD_HASH is not a bcrypt hash — single-quote it in" \
+    "db-sync.env so the shell doesn't expand the \$-delimited fields." >&2
+  exit 1
+fi
 
 PROD_URL="postgresql://${PROD_DB_USER}:${PROD_DB_PASSWORD}@${PROD_DB_HOST}:5432/${PROD_DB_NAME}"
 
@@ -150,7 +157,7 @@ data from its previous successful sync."
   fi
 
   echo "[$(date)] ==> ${outcome}"
-  notify_slack "${emoji} prod → staging: ${outcome}"
+  notify_slack "${emoji} prod → staging (${TIMESTAMP}): ${outcome}"
 
   if [ "$status" -eq 0 ]; then
     ping_healthcheck
@@ -164,15 +171,8 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 trap 'exit 129' HUP
 
-BCRYPT_PATTERN='^\$2[aby]\$[0-9]{2}\$[./A-Za-z0-9]{53}$'
-if [[ ! $STAGING_PASSWORD_HASH =~ $BCRYPT_PATTERN ]]; then
-  echo "STAGING_PASSWORD_HASH is not a bcrypt hash — single-quote it in" \
-    "db-sync.env so the shell doesn't expand the \$-delimited fields." >&2
-  exit 1
-fi
-
 echo "[$(date)] ==> Starting prod → staging sync"
-notify_slack ":hourglass_flowing_sand: prod → staging: sync started."
+notify_slack ":hourglass_flowing_sand: prod → staging (${TIMESTAMP}): sync started."
 ping_healthcheck /start
 
 STAGE="dump"

--- a/scripts/sync_prod_to_staging.sh
+++ b/scripts/sync_prod_to_staging.sh
@@ -26,6 +26,21 @@ notify_slack() {
     || echo "[$(date)] ==> WARNING: could not post to Slack."
 }
 
+# A Slack message only reports a run that lived long enough to send it. A
+# SIGKILL, a dead host, or a cron that never fires sends nothing at all, so the
+# ping that never arrives has to be what raises the alarm.
+#
+# The startup trap fires above the HEALTHCHECK_URL check, so an unset variable
+# is a no-op here instead of a curl error about a URL with no host.
+ping_healthcheck() {
+  local base="${HEALTHCHECK_URL:-}"
+  [ -n "$base" ] || return 0
+  curl --silent --show-error --fail --max-time 10 \
+    --retry 3 --retry-connrefused --retry-max-time 30 \
+    "${base%/}${1:-}" >/dev/null \
+    || echo "[$(date)] ==> WARNING: could not ping the healthcheck."
+}
+
 # cleanup reads paths built further down, so it can't be the trap yet. This one
 # reports the only startup failure that can reach Slack, a db-sync.env that
 # loads but is missing a variable.
@@ -33,6 +48,7 @@ report_startup_failure() {
   notify_slack ":x: prod → staging: FAILED during startup, before the sync \
 began. Check db-sync.env on the staging host. Staging still holds the data from \
 its previous successful sync."
+  ping_healthcheck /fail
   exit 1
 }
 trap report_startup_failure EXIT
@@ -47,7 +63,8 @@ trap report_startup_failure EXIT
   "${STAGING_DB_NAME:?missing in db-sync.env}" \
   "${STAGING_PASSWORD_HASH:?missing in db-sync.env}" \
   "${PROD_ASSETS_BUCKET:?missing in db-sync.env}" \
-  "${STAGING_ASSETS_BUCKET:?missing in db-sync.env}"
+  "${STAGING_ASSETS_BUCKET:?missing in db-sync.env}" \
+  "${HEALTHCHECK_URL:?missing in db-sync.env}"
 
 PROD_URL="postgresql://${PROD_DB_USER}:${PROD_DB_PASSWORD}@${PROD_DB_HOST}:5432/${PROD_DB_NAME}"
 
@@ -95,6 +112,12 @@ data from its previous successful sync."
 
   echo "[$(date)] ==> ${outcome}"
   notify_slack "${emoji} prod → staging: ${outcome}"
+
+  if [ "$status" -eq 0 ]; then
+    ping_healthcheck
+  else
+    ping_healthcheck /fail
+  fi
 }
 trap cleanup EXIT
 
@@ -111,6 +134,7 @@ fi
 
 echo "[$(date)] ==> Starting prod → staging sync"
 notify_slack ":hourglass_flowing_sand: prod → staging: sync started."
+ping_healthcheck /start
 
 STAGE="dump"
 echo "[$(date)] ==> Dumping prod database to ${DUMP_FILE}..."

--- a/scripts/sync_prod_to_staging.sh
+++ b/scripts/sync_prod_to_staging.sh
@@ -8,6 +8,35 @@ umask 077
 
 source /home/ec2-user/db-sync.env
 
+# Checked ahead of the traps below, and of every other variable, because a trap
+# has no way to report its own failure without these two.
+: "${SLACK_WEBHOOK_URL:?missing in db-sync.env}"
+
+if ! command -v jq >/dev/null; then
+  echo "jq is not installed; the sync needs it to post results to Slack." >&2
+  exit 1
+fi
+
+notify_slack() {
+  curl --silent --show-error --fail --max-time 10 \
+    --retry 3 --retry-connrefused \
+    --header 'Content-Type: application/json' \
+    --data "$(jq -nc --arg text "$1" '{text: $text}')" \
+    "$SLACK_WEBHOOK_URL" >/dev/null \
+    || echo "[$(date)] ==> WARNING: could not post to Slack."
+}
+
+# cleanup reads paths built further down, so it can't be the trap yet. This one
+# reports the only startup failure that can reach Slack, a db-sync.env that
+# loads but is missing a variable.
+report_startup_failure() {
+  notify_slack ":x: prod → staging: FAILED during startup, before the sync \
+began. Check db-sync.env on the staging host. Staging still holds the data from \
+its previous successful sync."
+  exit 1
+}
+trap report_startup_failure EXIT
+
 : "${PROD_DB_USER:?missing in db-sync.env}" \
   "${PROD_DB_PASSWORD:?missing in db-sync.env}" \
   "${PROD_DB_HOST:?missing in db-sync.env}" \
@@ -20,13 +49,6 @@ source /home/ec2-user/db-sync.env
   "${PROD_ASSETS_BUCKET:?missing in db-sync.env}" \
   "${STAGING_ASSETS_BUCKET:?missing in db-sync.env}"
 
-BCRYPT_PATTERN='^\$2[aby]\$[0-9]{2}\$[./A-Za-z0-9]{53}$'
-if [[ ! $STAGING_PASSWORD_HASH =~ $BCRYPT_PATTERN ]]; then
-  echo "STAGING_PASSWORD_HASH is not a bcrypt hash — single-quote it in" \
-    "db-sync.env so the shell doesn't expand the \$-delimited fields." >&2
-  exit 1
-fi
-
 PROD_URL="postgresql://${PROD_DB_USER}:${PROD_DB_PASSWORD}@${PROD_DB_HOST}:5432/${PROD_DB_NAME}"
 
 STAGING_ADMIN_URL="postgresql://${STAGING_DB_USER}:${STAGING_DB_PASSWORD}@${STAGING_DB_HOST}:5432/postgres"
@@ -38,6 +60,7 @@ TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 DUMP_FILE="/home/ec2-user/prod_dump_${TIMESTAMP}.pgcustom"
 
 SWAP_STARTED=0
+STAGE="startup"
 
 # The dump file and the scratch database both hold unanonymized prod data, so
 # every exit path has to take them with it — until the swap starts, after which
@@ -54,16 +77,24 @@ cleanup() {
         "hold unanonymized prod data."
   fi
 
-  if [ "$status" -ne 0 ]; then
-    if [ "$SWAP_STARTED" -eq 1 ]; then
-      echo "[$(date)] ==> FAILED (exit ${status}) at or after the swap." \
-        "If ${STAGING_DB_NAME} no longer exists, recover with:" \
-        "ALTER DATABASE ${SCRATCH_DB} RENAME TO ${STAGING_DB_NAME};"
-    else
-      echo "[$(date)] ==> FAILED (exit ${status}). Staging still holds the data" \
-        "from its previous successful sync."
-    fi
+  local emoji outcome
+
+  if [ "$status" -eq 0 ]; then
+    emoji=":white_check_mark:"
+    outcome="Sync completed successfully."
+  elif [ "$SWAP_STARTED" -eq 1 ]; then
+    emoji=":x:"
+    outcome="FAILED during ${STAGE} (exit ${status}) at or after the swap. \
+If ${STAGING_DB_NAME} no longer exists, recover with: \
+ALTER DATABASE ${SCRATCH_DB} RENAME TO ${STAGING_DB_NAME};"
+  else
+    emoji=":x:"
+    outcome="FAILED during ${STAGE} (exit ${status}). Staging still holds the \
+data from its previous successful sync."
   fi
+
+  echo "[$(date)] ==> ${outcome}"
+  notify_slack "${emoji} prod → staging: ${outcome}"
 }
 trap cleanup EXIT
 
@@ -71,7 +102,15 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 trap 'exit 129' HUP
 
+BCRYPT_PATTERN='^\$2[aby]\$[0-9]{2}\$[./A-Za-z0-9]{53}$'
+if [[ ! $STAGING_PASSWORD_HASH =~ $BCRYPT_PATTERN ]]; then
+  echo "STAGING_PASSWORD_HASH is not a bcrypt hash — single-quote it in" \
+    "db-sync.env so the shell doesn't expand the \$-delimited fields." >&2
+  exit 1
+fi
+
 echo "[$(date)] ==> Starting prod → staging sync"
+STAGE="dump"
 echo "[$(date)] ==> Dumping prod database to ${DUMP_FILE}..."
 
 pg_dump \
@@ -81,6 +120,7 @@ pg_dump \
   "$PROD_URL" \
   --file="$DUMP_FILE"
 
+STAGE="scratch database"
 echo "[$(date)] ==> Recreating scratch database ${SCRATCH_DB}..."
 
 psql "$STAGING_ADMIN_URL" -v ON_ERROR_STOP=1 <<SQL
@@ -88,6 +128,7 @@ DROP DATABASE IF EXISTS ${SCRATCH_DB} WITH (FORCE);
 CREATE DATABASE ${SCRATCH_DB} WITH TEMPLATE=template0 ENCODING='UTF8';
 SQL
 
+STAGE="restore"
 echo "[$(date)] ==> Restoring dump into ${SCRATCH_DB}..."
 
 pg_restore \
@@ -97,6 +138,7 @@ pg_restore \
   --dbname="$SCRATCH_URL" \
   "$DUMP_FILE"
 
+STAGE="anonymize"
 echo "[$(date)] ==> Anonymizing ${SCRATCH_DB}..."
 
 psql "$SCRATCH_URL" -v ON_ERROR_STOP=1 --single-transaction \
@@ -240,6 +282,7 @@ UPDATE "push" SET "expoPushToken" = 'pruned';
 
 SQL
 
+STAGE="swap"
 echo "[$(date)] ==> Swapping ${SCRATCH_DB} into place as ${STAGING_DB_NAME}..."
 
 SWAP_STARTED=1
@@ -253,6 +296,7 @@ DROP DATABASE IF EXISTS ${STAGING_DB_NAME} WITH (FORCE);
 ALTER DATABASE ${SCRATCH_DB} RENAME TO ${STAGING_DB_NAME};
 SQL
 
+STAGE="s3 sync"
 echo "[$(date)] ==> S3 sync s3://$PROD_ASSETS_BUCKET -> s3://$STAGING_ASSETS_BUCKET"
 
 aws s3 sync \
@@ -268,5 +312,3 @@ if [ $SYNC_EXIT -ne 0 ]; then
 fi
 
 echo "[$(date)] ==> S3 sync complete."
-
-echo "[$(date)] ==> Sync completed successfully."

--- a/scripts/sync_prod_to_staging.sh
+++ b/scripts/sync_prod_to_staging.sh
@@ -110,6 +110,8 @@ if [[ ! $STAGING_PASSWORD_HASH =~ $BCRYPT_PATTERN ]]; then
 fi
 
 echo "[$(date)] ==> Starting prod → staging sync"
+notify_slack ":hourglass_flowing_sand: prod → staging: sync started."
+
 STAGE="dump"
 echo "[$(date)] ==> Dumping prod database to ${DUMP_FILE}..."
 


### PR DESCRIPTION
`scripts/sync_prod_to_staging.sh` runs nightly from cron on the staging host and, until now, said nothing when it went wrong. A failed sync showed up as staging quietly serving last week's data, whenever someone happened to notice.

Every run now posts its outcome to Slack from the EXIT trap, with the stage it died in and whether staging still holds the data from its last good sync. The trap only fires if the shell lives long enough to run it, so a run also posts when it starts. A start with nothing after it is a run that got killed.

Slack has no alarm for a message that never arrives, so the run also pings a healthchecks.io check, `/start` before the dump and a bare ping on success. That covers what Slack cannot: a cron that never fires, a `db-sync.env` that will not source, a missing `jq`. All of them die before the first curl and now surface as a missed ping. `HEALTHCHECK_URL` is required like every other variable, because a monitor that turns itself off when someone forgets to set it is worse than no monitor.

Two runs sharing the scratch database and the staging database can leave staging dropped, or, in the quieter ordering, rename one run's unanonymized database into place as staging. Runs now serialize on a lock file with `flock`. That lock lives on the open file description rather than the process, so every external command runs through a wrapper that closes the fd for it. Without that, an orphaned `pg_dump` would hold the lock and skip every run after it. A skipped run posts and exits 0, since the nightly cron colliding with a manual re-run is the expected way to hit this.

The start and the outcome carry the run's timestamp, which is the same timestamp in the dump filename the host log prints. That is how you tell which start an outcome belongs to hours later, and how a message in Slack leads to its own lines in the log.

`docs/monitoring.md` records what `db-sync.env` holds, which nothing in the repo said before. One thing to do before this merges: the deploy reinstalls the script on staging, and the first run after that refuses to start unless `HEALTHCHECK_URL` is set in `db-sync.env` on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQGrGTYXB7HpaKutdUAo2c
