### PR TITLE
Fix markdown and biglink handling on mobile and the web

### DIFF
--- a/apps/admin/src/root.tsx
+++ b/apps/admin/src/root.tsx
@@ -1,5 +1,6 @@
 import { client } from "@alliance/shared/client/client.gen";
 import { useNumberInputScrollGuard } from "@alliance/sharedweb/lib/useNumberInputScrollGuard";
+import { AuthoredLinkProvider } from "@alliance/sharedweb/ui/SiteAppProvider";
 import { ToastProvider } from "@alliance/sharedweb/ui/ToastProvider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
@@ -78,13 +79,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        <QueryClientProvider client={queryClient}>
-          <AuthProvider>
-            <GroupAssignmentProvider>
-              <ToastProvider>{children}</ToastProvider>
-            </GroupAssignmentProvider>
-          </AuthProvider>
-        </QueryClientProvider>
+        <AuthoredLinkProvider>
+          <QueryClientProvider client={queryClient}>
+            <AuthProvider>
+              <GroupAssignmentProvider>
+                <ToastProvider>{children}</ToastProvider>
+              </GroupAssignmentProvider>
+            </AuthProvider>
+          </QueryClientProvider>
+        </AuthoredLinkProvider>
         <ScrollRestoration />
         <Scripts />
       </body>

--- a/apps/frontend/src/root.tsx
+++ b/apps/frontend/src/root.tsx
@@ -1,6 +1,7 @@
 import { client } from "@alliance/shared/client/client.gen";
 import { registerAnalytics } from "@alliance/shared/lib/analytics";
 import { useNumberInputScrollGuard } from "@alliance/sharedweb/lib/useNumberInputScrollGuard";
+import { SiteAppProvider } from "@alliance/sharedweb/ui/SiteAppProvider";
 import { ToastProvider } from "@alliance/sharedweb/ui/ToastProvider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import posthog, { PostHogConfig } from "posthog-js";
@@ -108,13 +109,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
   useNumberInputScrollGuard();
 
   const inner = (
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider queryClient={queryClient}>
-        <ToastProvider>
-          <HtmlBackgroundManager>{children}</HtmlBackgroundManager>
-        </ToastProvider>
-      </AuthProvider>
-    </QueryClientProvider>
+    <SiteAppProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider queryClient={queryClient}>
+          <ToastProvider>
+            <HtmlBackgroundManager>{children}</HtmlBackgroundManager>
+          </ToastProvider>
+        </AuthProvider>
+      </QueryClientProvider>
+    </SiteAppProvider>
   );
 
   return (

--- a/apps/mobile/components/markdownStyles.ts
+++ b/apps/mobile/components/markdownStyles.ts
@@ -121,13 +121,15 @@ export function useMarkdownTextStyles(): MarkdownTextStyles {
 }
 
 /**
- * The library's full-width paragraph stretches chat bubbles, while its default
- * flexWrap disables flexShrink in Yoga. Each paragraph has one textgroup, so
- * nowrap preserves layout while allowing the bubble to shrink to fit.
+ * The library's full-width paragraph stretches chat bubbles, so width auto lets
+ * the bubble hug its text. A hardbreak splits the paragraph into one textgroup
+ * per line, which a column stacks and a row collapses to zero width. Nowrap
+ * because Yoga's wrap disables flexShrink.
  */
 export const MARKDOWN_HUG_WIDTH_STYLE = {
   paragraph: {
     width: "auto",
+    flexDirection: "column",
     flexWrap: "nowrap",
     flexShrink: 1,
   },

--- a/apps/mobile/lib/internalLinks.test.ts
+++ b/apps/mobile/lib/internalLinks.test.ts
@@ -54,7 +54,37 @@ describe("getInternalRoute", () => {
     expect(getInternalRoute("/feed")).toBe("/feed");
   });
 
+  it("routes a path written without a leading slash", () => {
+    expect(getInternalRoute("forum/post/22")).toBe("/forum/post/22");
+    expect(getInternalRoute("actions/5")).toBe("/actions/5");
+    expect(getInternalRoute("search")).toBe("/search");
+    expect(getInternalRoute("feed/146?ref=email")).toBe(
+      "/actions/146?tab=activity&ref=email",
+    );
+  });
+
+  it("keeps the query string and hash on a schemeless path", () => {
+    expect(getInternalRoute("forum/post/22#c3")).toBe("/forum/post/22#c3");
+    expect(getInternalRoute("member/7?tab=posts")).toBe("/member/7?tab=posts");
+  });
+
+  it("declines a URL that carries a scheme", () => {
+    expect(getInternalRoute("mailto:a@b.org")).toBeNull();
+    expect(getInternalRoute("tel:+15551234567")).toBeNull();
+    expect(
+      getInternalRoute("https://worldalliance.org/forum/post/22"),
+    ).toBeNull();
+    expect(getInternalRoute("JAVASCRIPT:alert(1)")).toBeNull();
+  });
+
+  it("declines a protocol-relative URL", () => {
+    expect(getInternalRoute("//worldalliance.org/forum/post/22")).toBeNull();
+  });
+
   it("is null for a path with no screen", () => {
     expect(getInternalRoute("/api/images/1765.webp")).toBeNull();
+    expect(getInternalRoute("faq")).toBeNull();
+    expect(getInternalRoute("#intro")).toBeNull();
+    expect(getInternalRoute("?q=hi")).toBeNull();
   });
 });

--- a/apps/mobile/lib/internalLinks.ts
+++ b/apps/mobile/lib/internalLinks.ts
@@ -1,4 +1,5 @@
 import { isAllianceAppHostname } from "@alliance/common/url";
+import { urlProtocol } from "@alliance/common/url-safety";
 
 /**
  * Route patterns that can be handled internally by the mobile app.
@@ -97,25 +98,28 @@ const INTERNAL_ROUTE_PATTERNS: {
 ];
 
 /**
- * Check if a URL is a relative path that can be handled internally
+ * The in-app route for one of our own paths, with or without a leading slash,
+ * or null when the URL belongs somewhere else.
  */
 export function getInternalRoute(url: string): string | null {
-  // Only process relative URLs (starting with /)
-  if (!url.startsWith("/")) {
+  // A scheme or a `//host` prefix addresses somewhere else; anything else is
+  // one of our paths, however the author wrote it.
+  if (urlProtocol(url) !== null || url.startsWith("//")) {
     return null;
   }
+  const path = url.startsWith("/") ? url : `/${url}`;
 
   // Extract query string and hash to preserve them
-  const queryIndex = url.indexOf("?");
-  const hashIndex = url.indexOf("#");
+  const queryIndex = path.indexOf("?");
+  const hashIndex = path.indexOf("#");
   const suffixStart =
     queryIndex >= 0 && hashIndex >= 0
       ? Math.min(queryIndex, hashIndex)
       : queryIndex >= 0
         ? queryIndex
         : hashIndex;
-  const pathOnly = suffixStart >= 0 ? url.slice(0, suffixStart) : url;
-  const suffix = suffixStart >= 0 ? url.slice(suffixStart) : "";
+  const pathOnly = suffixStart >= 0 ? path.slice(0, suffixStart) : path;
+  const suffix = suffixStart >= 0 ? path.slice(suffixStart) : "";
 
   for (const { pattern, getRoute } of INTERNAL_ROUTE_PATTERNS) {
     const match = pathOnly.match(pattern);

--- a/common/src/url.test.ts
+++ b/common/src/url.test.ts
@@ -1,4 +1,4 @@
-import { isAllianceAppHostname, urlMatchesDomain } from "./url";
+import { isAllianceAppHostname, siteHref, urlMatchesDomain } from "./url";
 
 describe("urlMatchesDomain", () => {
   it("matches the domain itself and its subdomains", () => {
@@ -56,5 +56,48 @@ describe("isAllianceAppHostname", () => {
     expect(isAllianceAppHostname("thealliance.org.evil.com")).toBe(false);
     expect(isAllianceAppHostname("notthealliance.org")).toBe(false);
     expect(isAllianceAppHostname("example.com")).toBe(false);
+  });
+});
+
+describe("siteHref", () => {
+  it("strips the web app's own hosts down to a path", () => {
+    expect(siteHref("https://worldalliance.org/forum/post/22")).toBe(
+      "/forum/post/22",
+    );
+    expect(siteHref("https://www.thealliance.org/actions/5")).toBe(
+      "/actions/5",
+    );
+    expect(siteHref("https://www.staging.thealliance.org/actions/5")).toBe(
+      "/actions/5",
+    );
+  });
+
+  it("keeps the query and hash", () => {
+    expect(
+      siteHref("https://worldalliance.org/actions/5?tab=tasks#comments"),
+    ).toBe("/actions/5?tab=tasks#comments");
+  });
+
+  it("leaves paths alone", () => {
+    expect(siteHref("/forum/post/22")).toBe("/forum/post/22");
+    expect(siteHref("#comments")).toBe("#comments");
+  });
+
+  it("keeps a path that would resolve against another host absolute", () => {
+    expect(siteHref("https://worldalliance.org//evil.com/x")).toBe(
+      "https://worldalliance.org//evil.com/x",
+    );
+  });
+
+  it("leaves everywhere else as authored", () => {
+    expect(siteHref("https://admin.worldalliance.org/actions/5")).toBe(
+      "https://admin.worldalliance.org/actions/5",
+    );
+    expect(siteHref("https://www.regulations.gov/document/FS-1")).toBe(
+      "https://www.regulations.gov/document/FS-1",
+    );
+    expect(siteHref("mailto:contact@worldalliance.org")).toBe(
+      "mailto:contact@worldalliance.org",
+    );
   });
 });

--- a/common/src/url.ts
+++ b/common/src/url.ts
@@ -78,3 +78,27 @@ export const isAllianceAppHostname = (hostname: string): boolean => {
     ALLIANCE_APP_SUBDOMAINS.some((prefix) => host === `${prefix}${domain}`),
   );
 };
+
+/**
+ * An authored link, aimed at the domain the reader is already on: a link to one
+ * of the web app's own hosts comes back as a bare path, for the browser to
+ * resolve against the current one. Anything else is returned as authored.
+ */
+export const siteHref = (url: string): string => {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  if (
+    (parsed.protocol !== "https:" && parsed.protocol !== "http:") ||
+    !isAllianceAppHostname(parsed.hostname)
+  ) {
+    return url;
+  }
+  const path = parsed.pathname + parsed.search + parsed.hash;
+  // A path opening with `//` reads as protocol-relative: the browser would
+  // resolve it against the host that follows, not the current one.
+  return path.startsWith("//") ? url : path;
+};

--- a/sharedweb/forms/RenderDisplayBlock.test.tsx
+++ b/sharedweb/forms/RenderDisplayBlock.test.tsx
@@ -1,5 +1,10 @@
-import type { AccordionBlock } from "@alliance/common/forms/display-blocks";
+import type {
+  AccordionBlock,
+  BigLinkBlock,
+} from "@alliance/common/forms/display-blocks";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { AuthoredLinkProvider, SiteAppProvider } from "../ui/SiteAppProvider";
 import RenderDisplayBlock from "./RenderDisplayBlock";
 
 afterEach(cleanup);
@@ -50,5 +55,56 @@ describe("the accordion display block", () => {
 
     expect(screen.queryByText("Inside one")).toBeNull();
     expect(screen.getByText("Inside two")).toBeTruthy();
+  });
+});
+
+const biglink: BigLinkBlock = {
+  type: "display",
+  kind: "biglink",
+  id: "block-1",
+  text: "Read the post",
+  url: "https://worldalliance.org/forum/post/22",
+};
+
+const hrefOf = (node: React.ReactNode): string | null => {
+  render(<MemoryRouter>{node}</MemoryRouter>);
+  return screen.getByRole("link").getAttribute("href");
+};
+
+describe("the biglink display block", () => {
+  it("drops our own domain in the app that serves it", () => {
+    expect(
+      hrefOf(
+        <SiteAppProvider>
+          <RenderDisplayBlock block={biglink} />
+        </SiteAppProvider>,
+      ),
+    ).toBe("/forum/post/22");
+  });
+
+  it("shows the destination it links to", () => {
+    render(
+      <MemoryRouter>
+        <SiteAppProvider>
+          <RenderDisplayBlock block={biglink} />
+        </SiteAppProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText(biglink.url)).toBeNull();
+    expect(screen.getByText("/forum/post/22")).toBeTruthy();
+  });
+
+  it("keeps the authored URL in an app that serves another domain", () => {
+    expect(
+      hrefOf(
+        <AuthoredLinkProvider>
+          <RenderDisplayBlock block={biglink} />
+        </AuthoredLinkProvider>,
+      ),
+    ).toBe("https://worldalliance.org/forum/post/22");
+  });
+
+  it("refuses to render in an app that has claimed neither", () => {
+    expect(() => hrefOf(<RenderDisplayBlock block={biglink} />)).toThrow();
   });
 });

--- a/sharedweb/forms/RenderDisplayBlock.tsx
+++ b/sharedweb/forms/RenderDisplayBlock.tsx
@@ -2,6 +2,7 @@ import {
   CHAT_TRANSCRIPT_SIZE_UNIT_PX,
   groupChatTranscriptMessages,
   type AccordionBlock,
+  type BigLinkBlock,
   type BigLinkIcon,
   type DisplayBlock,
   type ImagesItem,
@@ -33,6 +34,7 @@ import { AvatarProfile } from "../ui/Avatar";
 import Card from "../ui/Card";
 import FormMarkdownWrapper from "../ui/FormMarkdownWrapper";
 import ImageLightbox from "../ui/ImageLightbox";
+import { useSiteHref } from "../ui/SiteAppProvider";
 import RenderPreviousAnswer from "./RenderPreviousAnswer";
 import VideoPlayer from "./VideoPlayer";
 
@@ -224,6 +226,34 @@ function ImagesDisplay({ images }: { images: ImagesItem[] }) {
   );
 }
 
+function BigLinkDisplay({ block }: { block: BigLinkBlock }) {
+  const siteHref = useSiteHref();
+  const IconComponent = bigLinkIcons[block.icon || "messages-square"];
+  const href = siteHref(block.url);
+
+  return (
+    <Link
+      to={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block group text-black "
+    >
+      <Card
+        className="flex flex-row items-center gap-3 hover:bg-zinc-100"
+        style={CardStyle.Grey}
+      >
+        <IconComponent size={20} />
+        <div>
+          <p className="text-base" style={{ fontWeight: 450 }}>
+            {block.text}
+          </p>
+          <p className="text-sm text-green">{href}</p>
+        </div>
+      </Card>
+    </Link>
+  );
+}
+
 function AccordionDisplay({ block }: { block: AccordionBlock }) {
   return (
     <Accordion.Root
@@ -359,30 +389,8 @@ export default function RenderDisplayBlock({
         </div>
       );
 
-    case "biglink": {
-      const IconComponent = bigLinkIcons[block.icon || "messages-square"];
-      return (
-        <Link
-          to={block.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block group text-black "
-        >
-          <Card
-            className="flex flex-row items-center gap-3 hover:bg-zinc-100"
-            style={CardStyle.Grey}
-          >
-            <IconComponent size={20} />
-            <div>
-              <p className="text-base" style={{ fontWeight: 450 }}>
-                {block.text}
-              </p>
-              <p className="text-sm text-green">{block.url}</p>
-            </div>
-          </Card>
-        </Link>
-      );
-    }
+    case "biglink":
+      return <BigLinkDisplay block={block} />;
 
     case "copytext":
       return <CopyTextDisplay text={block.text} title={block.title} />;

--- a/sharedweb/ui/SiteAppProvider.tsx
+++ b/sharedweb/ui/SiteAppProvider.tsx
@@ -1,0 +1,36 @@
+import { siteHref } from "@alliance/common/url";
+import React, { createContext, useContext } from "react";
+
+const SiteAppContext = createContext<boolean | undefined>(undefined);
+
+const asAuthored = (url: string): string => url;
+
+/**
+ * Marks the app served on worldalliance.org and thealliance.org, the only one
+ * where an authored link to either domain can be reduced to a path.
+ */
+export function SiteAppProvider({ children }: React.PropsWithChildren) {
+  return (
+    <SiteAppContext.Provider value={true}>{children}</SiteAppContext.Provider>
+  );
+}
+
+/**
+ * Marks an app served on some other host — the admin, on admin.<domain>, whose
+ * router has no route for a path on the site. Links stay as authored.
+ */
+export function AuthoredLinkProvider({ children }: React.PropsWithChildren) {
+  return (
+    <SiteAppContext.Provider value={false}>{children}</SiteAppContext.Provider>
+  );
+}
+
+export const useSiteHref = (): ((url: string) => string) => {
+  const servesTheSite = useContext(SiteAppContext);
+  if (servesTheSite === undefined) {
+    throw new Error(
+      "no SiteAppProvider or AuthoredLinkProvider is mounted: an app has to say whether it is served on the site's own hosts before it can render a link to them",
+    );
+  }
+  return servesTheSite ? siteHref : asAuthored;
+};


### PR DESCRIPTION
Three fixes to how authored links and markdown render, one commit each.

**Render chat bubble text that follows a markdown hardbreak** — the hug style kept its paragraph a nowrap row, so the library's `width: '100%'` hardbreak claimed the whole line and the textgroups on either side shrank to nothing. Bubbles drew thousands of pixels tall with no text in them. Stacking the paragraph gives each textgroup its own line and still hugs.

**Keep biglinks on the domain the reader is already browsing** — most biglinks are stored absolute against worldalliance.org, so on thealliance.org react-router rendered a cross-origin anchor and threw the reader back to the old domain. A link on one of the web app's own hosts is reduced to a path for the browser to resolve, and the card prints that path so the destination it advertises is the one it goes to. Each web app declares which it is: the frontend is served on those hosts, the admin mounts the provider that keeps links as authored, and rendering a biglink with neither mounted throws.

**Route schemeless internal links in the mobile app** — a biglink saved as `forum/post/22` fell through to the system browser because `getInternalRoute` required a leading slash. It now accepts a path however the author wrote it, while a URL carrying a scheme or a `//host` prefix still goes elsewhere.

## Testing

`bun run typecheck` per package, `bun run test`, and `bun run format:check` pass.

## Follow-ups

Not in this PR:

- The same schemeless biglink is still broken on the web: `forum/post/22` renders as a react-router relative link, so a reader on `/actions/12` lands on `/actions/12/forum/post/22`. The fix is to normalize in `siteHref` so both platforms read a stored URL the same way.
- `isSafeLinkUrl` in `common/src/url-safety.ts` still has no caller, so `useHandleLinkPress` hands any unrecognised scheme to `Linking.openURL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SbAAjnXPJspi1BP3tNhW1