### PR TITLE
Update democratic grantmaking committed amount to $36,300

### DIFF
--- a/apps/frontend/src/components/projects/democratic-grantmaking-26/DemocraticGrantmaking26.tsx
+++ b/apps/frontend/src/components/projects/democratic-grantmaking-26/DemocraticGrantmaking26.tsx
@@ -46,7 +46,7 @@ export default function DemocraticGrantmaking26() {
                   1,000 members will work together to make a significant grant.
                 </p>
                 <p className="text-xl text-white/80 md:text-2xl">
-                  <span className="font-semibold text-green">$35,300</span>{" "}
+                  <span className="font-semibold text-green">$36,300</span>{" "}
                   committed by funders so far
                 </p>
               </div>

--- a/apps/frontend/src/pages/app/SignupPage.tsx
+++ b/apps/frontend/src/pages/app/SignupPage.tsx
@@ -120,7 +120,7 @@ function GrantmakingCard() {
       </p>
       <span className="mt-10 flex items-end justify-between gap-4">
         <span className="text-lg text-white/80 sm:text-xl">
-          <span className="font-semibold text-green">$35,300</span> committed so
+          <span className="font-semibold text-green">$36,300</span> committed so
           far
         </span>
         <SiteArrow className="mb-1 size-5 shrink-0 transition-transform duration-300 ease-out group-hover:translate-x-1 group-hover:-translate-y-1" />


### PR DESCRIPTION
## Summary
- Funders have committed more since the copy was last written; updates the $35,300 figure to $36,300 in both places it appears.

## Test plan
- [ ] Visually confirm the signup page's grantmaking teaser card shows $36,300
- [ ] Visually confirm the democratic-grantmaking-26 project page shows $36,300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the displayed committed funding amount from $35,300 to $36,300 on the Democratic Grantmaking ’26 landing page and signup page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->